### PR TITLE
Update admin credential defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Default admin credentials for basic auth
+ADMIN_USER=sekishuu
+ADMIN_PASS=16731227

--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Admin Authentication
+
+The `/admin` area is protected by HTTP Basic authentication. Default credentials can be configured using environment variables:
+
+```
+ADMIN_USER=sekishuu
+ADMIN_PASS=16731227
+```
+
+Create a `.env` file based on `.env.example` to customize these values.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.startsWith('/admin')) {
+    const basicAuth = request.headers.get('authorization')
+    const validUser = process.env.ADMIN_USER || 'sekishuu'
+    const validPass = process.env.ADMIN_PASS || '16731227'
+
+    if (basicAuth) {
+      const [scheme, encoded] = basicAuth.split(' ')
+      if (scheme === 'Basic' && encoded) {
+        const decoded = atob(encoded)
+        const [user, pass] = decoded.split(':')
+        if (user === validUser && pass === validPass) {
+          return NextResponse.next()
+        }
+      }
+    }
+
+    return new NextResponse('Authentication required', {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'Basic realm="Secure Area"',
+      },
+    })
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+}


### PR DESCRIPTION
## Summary
- 管理ページ用 Basic 認証のデフォルトID/PW を `sekishuu` / `16731227` に変更
- README と `.env.example` を更新
- ミドルウェアのデフォルト値も修正

## Testing
- `npm run lint` *(失敗: `next` コマンドが見つかりません)*

------
https://chatgpt.com/codex/tasks/task_e_684312af13688324b1a8af3e6bdf0ad9