### PR TITLE
Enable user-provided recipient email

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ ADMIN_PASS=16731227
 ```
 
 Create a `.env` file based on `.env.example` to customize these values.
+
+## Email configuration
+
+The application sends reservation confirmations using the [Resend](https://resend.com/) service. Set your Resend API key in the environment so that `/api/send-email` can send emails:
+
+```bash
+RESEND_API_KEY=your_resend_api_key
+```
+
+The default sender address is `onboarding@resend.dev`, which works without additional domain verification.

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -7,10 +7,13 @@ export async function POST(req: Request) {
   console.log("✅ APIキー:", process.env.RESEND_API_KEY);
 
   try {
-    const { subject, html } = await req.json();
+    const { to, subject, html } = await req.json();
+
+    if (!to) {
+      throw new Error("送信先メールアドレスが指定されていません");
+    }
 
     // ✅ Freeプラン対応の送信設定
-    const to = "m-adachi@sustirel.com"; // 確実に届くアドレス
     const from = "onboarding@resend.dev"; // 認証不要な送信元
 
     // HTML未指定ならデフォルトに置き換え


### PR DESCRIPTION
## Summary
- allow `/api/send-email` to accept the recipient address
- document Resend API key setup in README

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431b08e840832480c8eb68e2b8cadc