### PR TITLE
Use FROM_EMAIL env variable for emails

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+FROM_EMAIL=noreply@sustirel.com

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The application sends reservation confirmations using the [Resend](https://resen
 
 ```bash
 RESEND_API_KEY=your_resend_api_key
+FROM_EMAIL=noreply@sustirel.com
 ```
 
-The default sender address is `onboarding@resend.dev`, which works without additional domain verification.
+By default the sender address is `onboarding@resend.dev`, but you can override it using the `FROM_EMAIL` variable as shown above.

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: Request) {
     }
 
     // ✅ Freeプラン対応の送信設定
-    const from = "onboarding@resend.dev"; // 認証不要な送信元
+    const from = process.env.FROM_EMAIL || "onboarding@resend.dev";
 
     // HTML未指定ならデフォルトに置き換え
     const htmlBody =


### PR DESCRIPTION
## Summary
- add `.env.local` with `FROM_EMAIL`
- use `FROM_EMAIL` in email API
- document `FROM_EMAIL` in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843b1d27ba08324b44c49e05bce1141