### PR TITLE
Improve reservation emails and button styling

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -24,7 +24,9 @@ interface Reservation {
   guests: number;
   eventId: string;
   seatTime: string;
+  notes?: string;
   createdAt: string;
+  password?: string;
 }
 
 export default function UserListPage() {

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -25,6 +25,7 @@ export default function EventDetailPage() {
   const [email, setEmail] = useState("");
   const [guests, setGuests] = useState(1);
   const [selectedTime, setSelectedTime] = useState("");
+  const [notes, setNotes] = useState("");
 
   useEffect(() => {
     const fetchEvent = async () => {
@@ -78,6 +79,7 @@ export default function EventDetailPage() {
     }
 
     const password = nanoid(8);
+    const totalCost = (event.cost || 0) * guests;
 
     await addDoc(collection(db, "reservations"), {
       name,
@@ -85,12 +87,16 @@ export default function EventDetailPage() {
       guests,
       eventId: event.id,
       seatTime: selectedTime,
+      notes,
       password,
       createdAt: new Date().toISOString(),
     });
 
     await updateSeatReservedCount(event.id);
     await updateParticipantCount(event.id);
+
+    const confirmUrl =
+      "https://sekishuu-nomura-ochakai.sustirel.com/reservations/confirm";
 
     await fetch("/api/send-email", {
       method: "POST",
@@ -99,17 +105,51 @@ export default function EventDetailPage() {
         to: email,
         subject: `${event.title} のご予約完了通知`,
         html: `
-          <p>${name}様</p>
-          <p>以下の内容でご予約を承りました。</p>
-          <ul>
-            <li>会場: ${event.venue}</li>
-            <li>日付: ${event.date.toDate().toLocaleDateString("ja-JP")}</li>
-            <li>時間: ${selectedTime}</li>
-            <li>人数: ${guests}名</li>
-          </ul>
-          <p>予約内容の確認・変更には下記の情報をご利用ください。</p>
-          <p><strong>予約時メールアドレス:</strong> ${email}<br/>
-          <strong>パスワード:</strong> ${password}</p>
+          <div style="font-family:sans-serif; line-height:1.6;">
+            <p>${name}様</p>
+            <p>以下の内容でご予約を承りました。</p>
+            <ul>
+              <li><strong>会場:</strong> ${event.venue}</li>
+              <li><strong>日付:</strong> ${event.date
+                .toDate()
+                .toLocaleDateString("ja-JP")}</li>
+              <li><strong>時間:</strong> ${selectedTime}</li>
+              <li><strong>人数:</strong> ${guests}名</li>
+            </ul>
+            <p><a href="${confirmUrl}">予約の確認/変更/キャンセルはこちらからお願いします。</a></p>
+            <p>予約内容の確認・変更には下記の情報をご利用ください。</p>
+            <p><strong>予約時メールアドレス:</strong> ${email}<br/>
+            <strong>パスワード:</strong> ${password}</p>
+            <p><strong>合計金額:</strong> ${totalCost}円</p>
+            <p>お支払いは以下にお振込みお願いします。</p>
+            <p>XXX銀行<br/>XXX支店<br/>普通 XXXXXXXX<br/>振込期限：X月X日<br/>振込人名義は（申込者様）のお名前にてお願いします。</p>
+          </div>
+        `,
+      }),
+    });
+
+    await fetch("/api/send-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        to: "m-adachi@sustirel.com",
+        subject: `${event.title} の予約が入りました`,
+        html: `
+          <div style="font-family:sans-serif; line-height:1.6;">
+            <p>${name}様から予約がありました。</p>
+            <ul>
+              <li><strong>イベント:</strong> ${event.title}</li>
+              <li><strong>会場:</strong> ${event.venue}</li>
+              <li><strong>日付:</strong> ${event.date
+                .toDate()
+                .toLocaleDateString("ja-JP")}</li>
+              <li><strong>時間:</strong> ${selectedTime}</li>
+              <li><strong>人数:</strong> ${guests}名</li>
+              <li><strong>メール:</strong> ${email}</li>
+              <li><strong>合計金額:</strong> ${totalCost}円</li>
+              <li><strong>自由記述:</strong> ${notes || "(なし)"}</li>
+            </ul>
+          </div>
         `,
       }),
     });
@@ -119,6 +159,7 @@ export default function EventDetailPage() {
     setEmail("");
     setGuests(1);
     setSelectedTime("");
+    setNotes("");
   };
 
   if (!event) return <p className="p-6">読み込み中...</p>;
@@ -182,6 +223,19 @@ export default function EventDetailPage() {
               </option>
             ))}
           </select>
+        </div>
+        <div>
+          <label className="block mb-1">
+            自由記述欄：なにか気になることや質問があればご記入ください。
+          </label>
+          <textarea
+            className="border p-2 w-full"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+          <p className="text-sm text-gray-500">
+            *担当者よりメールにてご連絡させていただきます
+          </p>
         </div>
         <button
           type="submit"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,11 +53,8 @@ export default function HomePage() {
       >
         <h1 className="text-5xl font-extrabold mt-2">石州流野村派</h1>
         <p className="mt-2 text-xl">お茶席予約サイト</p>
-        <button className="mt-4 bg-yellow-500 hover:bg-yellow-600 text-white py-2 px-4 rounded">
-          直近のお茶会
-        </button>
         <Link href="/reservations/confirm">
-          <button className="mt-2 bg-gray-600 hover:bg-gray-700 text-white py-2 px-4 rounded">
+          <button className="mt-2 bg-yellow-500 hover:bg-yellow-600 text-white py-2 px-4 rounded">
             予約の確認・変更はこちら
           </button>
         </Link>

--- a/types.ts
+++ b/types.ts
@@ -36,5 +36,7 @@ export interface Reservation {
   guests: number;
   eventId: string;
   seatTime: string;
+  notes?: string;
   createdAt: string;
+  password?: string;
 }


### PR DESCRIPTION
## Summary
- color tweak for the reservation lookup button on top page
- revise confirmation email text and formatting
- include all reservation details in admin notification email

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843d1d00b648324a5558fd5edc999e8