### PR TITLE
Add optional address input and multi-recipient emails

### DIFF
--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -23,7 +23,7 @@ const timeOptions = Array.from({ length: 22 }, (_, i) => {
   return `${String(hour).padStart(2, "0")}:${minute}`;
 });
 
-const capacityOptions = Array.from({ length: 30 }, (_, i) => i + 1);
+const capacityOptions = Array.from({ length: 200 }, (_, i) => i + 1);
 
 export default function EditEventPage() {
   const params = useParams();
@@ -35,7 +35,7 @@ export default function EditEventPage() {
     date: "",
     cost: 0,
     description: "",
-    seats: [{ time: "", capacity: 1, reserved: 0 }],
+    seats: [],
   });
   const router = useRouter();
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,11 +53,6 @@ export default function HomePage() {
       >
         <h1 className="text-5xl font-extrabold mt-2">石州流野村派</h1>
         <p className="mt-2 text-xl">お茶席予約サイト</p>
-        <Link href="/reservations/confirm">
-          <button className="mt-2 bg-yellow-500 hover:bg-yellow-600 text-white py-2 px-4 rounded">
-            予約の確認・変更はこちら
-          </button>
-        </Link>
       </section>
 
       {/* イベント一覧セクション */}
@@ -98,6 +93,16 @@ export default function HomePage() {
             </div>
           ))}
         </div>
+      </section>
+
+      {/* 予約確認へのリンク */}
+      <section className="py-6 bg-gray-100 text-center px-4">
+        <p className="mb-2 font-semibold">すでに予約済みの方はこちら</p>
+        <Link href="/reservations/confirm">
+          <button className="bg-yellow-500 hover:bg-yellow-600 text-white py-2 px-4 rounded">
+            予約の確認・変更はこちら
+          </button>
+        </Link>
       </section>
     </main>
   );

--- a/app/reservations/confirm/page.tsx
+++ b/app/reservations/confirm/page.tsx
@@ -40,7 +40,7 @@ export default function ReservationConfirmPage() {
 
   const updateReservation = async (
     id: string,
-    updatedData: { eventId: string; guests: number }
+    updatedData: { eventId: string; guests: number; address?: string }
   ) => {
     const reservationRef = doc(db, "reservations", id);
     const reservationSnap = await getDoc(reservationRef);
@@ -122,8 +122,9 @@ export default function ReservationConfirmPage() {
       {reservations.map((r) => (
         <div key={r.id} className="border p-4 mb-4">
           <p>イベントID: {r.eventId}</p>
-          <p>時間枠: {r.seatTime}</p>
+          <p>時間枠: {r.seatTime || "時間指定なし"}</p>
           <p>人数: {r.guests}</p>
+          <p>住所: {r.address || "(未入力)"}</p>
           <input
             type="number"
             min={1}
@@ -139,12 +140,28 @@ export default function ReservationConfirmPage() {
             }
             className="border p-1 my-2"
           />
+          <input
+            type="text"
+            value={r.address || ""}
+            onChange={(e) =>
+              setReservations((prev) =>
+                prev.map((item) =>
+                  item.id === r.id
+                    ? { ...item, address: e.target.value }
+                    : item
+                )
+              )
+            }
+            placeholder="住所（任意）"
+            className="border p-1 my-2 w-full"
+          />
           <button
             className="bg-green-600 text-white px-3 py-1 mr-2 rounded"
             onClick={() =>
               updateReservation(r.id, {
                 guests: r.guests,
                 eventId: r.eventId,
+                address: r.address,
               })
             }
           >

--- a/types.ts
+++ b/types.ts
@@ -33,6 +33,7 @@ export interface Reservation {
   id: string;
   name: string;
   email: string;
+  address?: string;
   guests: number;
   eventId: string;
   seatTime: string;


### PR DESCRIPTION
## Summary
- notify additional addresses for reservations
- allow 200-person capacity on event creation
- support no time slots for events
- switch guest count input to a dropdown and collect address when reserving
- display and edit address on reservation confirm page
- move reservation confirmation button below event list

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6857a98b510c83248d2749f87066cf3b