### PR TITLE
Add address editing for admin lists

### DIFF
--- a/app/admin/events/[id]/reservations/page.tsx
+++ b/app/admin/events/[id]/reservations/page.tsx
@@ -24,7 +24,12 @@ export default function EventReservationsPage() {
   const eventId = params?.id as string;
   const [reservations, setReservations] = useState<Reservation[]>([]);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editForm, setEditForm] = useState({ name: "", guests: 1, seatTime: "" });
+  const [editForm, setEditForm] = useState({
+    name: "",
+    guests: 1,
+    seatTime: "",
+    address: "",
+  });
   const [availableTimes, setAvailableTimes] = useState<string[]>([]);
 
   useEffect(() => {
@@ -96,7 +101,7 @@ export default function EventReservationsPage() {
     await updateSeatReservedCount(eventId);
     alert("予約を更新しました");
     setEditingId(null);
-    setEditForm({ name: "", guests: 1, seatTime: "" });
+    setEditForm({ name: "", guests: 1, seatTime: "", address: "" });
 
     const snapshot = await getDocs(collection(db, "reservations"));
     const refreshed = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Reservation[];
@@ -145,6 +150,15 @@ export default function EventReservationsPage() {
                       </option>
                     ))}
                   </select>
+                  <input
+                    type="text"
+                    value={editForm.address}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, address: e.target.value })
+                    }
+                    className="border p-2 w-full"
+                    placeholder="住所(任意)"
+                  />
                   <div className="flex gap-2">
                     <button
                       onClick={handleEditSubmit}
@@ -167,12 +181,20 @@ export default function EventReservationsPage() {
                       👤 {res.name}（{res.guests}名）
                     </p>
                     <p className="text-sm text-gray-500">時間枠: {res.seatTime}</p>
+                    <p className="text-sm text-gray-500">
+                      住所: {res.address || "(未入力)"}
+                    </p>
                   </div>
                   <div className="flex gap-2 mt-2 sm:mt-0">
                     <button
                       onClick={() => {
                         setEditingId(res.id);
-                        setEditForm({ name: res.name, guests: res.guests, seatTime: res.seatTime });
+                        setEditForm({
+                          name: res.name,
+                          guests: res.guests,
+                          seatTime: res.seatTime,
+                          address: res.address || "",
+                        });
                       }}
                       className="px-3 py-1 text-sm bg-yellow-400 text-white rounded"
                     >

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -21,6 +21,7 @@ interface Reservation {
   id: string;
   name: string;
   email: string;
+  address?: string;
   guests: number;
   eventId: string;
   seatTime: string;
@@ -33,7 +34,13 @@ export default function UserListPage() {
   const [reservations, setReservations] = useState<Reservation[]>([]);
   const [eventTitles, setEventTitles] = useState<Record<string, string>>({});
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editForm, setEditForm] = useState({ name: "", email: "", guests: 1, seatTime: "" });
+  const [editForm, setEditForm] = useState({
+    name: "",
+    email: "",
+    address: "",
+    guests: 1,
+    seatTime: "",
+  });
   const [eventSeatTimes, setEventSeatTimes] = useState<Record<string, string[]>>({});
   const [eventSeatMap, setEventSeatMap] = useState<Record<string, Seat[]>>({});
 
@@ -127,7 +134,7 @@ export default function UserListPage() {
     await updateParticipantCount(eventId);
     await updateSeatReservedCount(eventId);
     setEditingId(null);
-    setEditForm({ name: "", email: "", guests: 1, seatTime: "" });
+    setEditForm({ name: "", email: "", address: "", guests: 1, seatTime: "" });
     const updated = await getDocs(collection(db, "reservations"));
     const dataUpdated = updated.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Reservation[];
     setReservations(dataUpdated);
@@ -145,6 +152,7 @@ export default function UserListPage() {
           <tr className="bg-gray-100">
             <th className="border px-2 py-1">名前</th>
             <th className="border px-2 py-1">メールアドレス</th>
+            <th className="border px-2 py-1">住所</th>
             <th className="border px-2 py-1">人数</th>
             <th className="border px-2 py-1">イベント名</th>
             <th className="border px-2 py-1">時間枠</th>
@@ -175,6 +183,17 @@ export default function UserListPage() {
                   />
                 ) : (
                   r.email
+                )}
+              </td>
+              <td className="border px-2 py-1">
+                {editingId === r.id ? (
+                  <input
+                    className="border p-1 w-full"
+                    value={editForm.address}
+                    onChange={(e) => setEditForm({ ...editForm, address: e.target.value })}
+                  />
+                ) : (
+                  r.address || ""
                 )}
               </td>
               <td className="border px-2 py-1">
@@ -230,7 +249,13 @@ export default function UserListPage() {
                     <button
                       onClick={() => {
                         setEditingId(r.id);
-                        setEditForm({ name: r.name, email: r.email, guests: r.guests, seatTime: r.seatTime });
+                        setEditForm({
+                          name: r.name,
+                          email: r.email,
+                          address: r.address || "",
+                          guests: r.guests,
+                          seatTime: r.seatTime,
+                        });
                       }}
                       className="bg-yellow-400 text-white px-2 py-1 rounded text-sm"
                     >


### PR DESCRIPTION
## Summary
- allow editing of reservation addresses in event reservations list
- show and edit addresses in overall user reservation list

## Testing
- `npx next lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b1a2686c8324b88c5d432875def9