### PR TITLE
Improve UI design

### DIFF
--- a/app/admin/events/[id]/reservations/page.tsx
+++ b/app/admin/events/[id]/reservations/page.tsx
@@ -119,7 +119,7 @@ export default function EventReservationsPage() {
           {reservations.map((res) => (
             <li
               key={res.id}
-              className="border p-4 rounded shadow-sm flex flex-col gap-2"
+              className="border p-4 rounded shadow-md bg-white flex flex-col gap-2"
             >
               {editingId === res.id ? (
                 <div className="space-y-2">

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -53,7 +53,7 @@ export default function AdminEventsPage() {
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {events.map((event) => (
-          <div key={event.id} className="border rounded p-4 shadow">
+          <div key={event.id} className="border rounded p-4 shadow-md bg-white">
             <h2 className="text-xl font-semibold mb-2">{event.title}</h2>
             <p className="text-gray-600 mb-1">
               📅{" "}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,14 +11,14 @@ export default function AdminDashboard() {
       <h1 className="text-2xl font-bold mb-6">管理ダッシュボード</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div
-          className="border rounded p-4 shadow hover:bg-gray-50 cursor-pointer"
+          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
           onClick={() => router.push("/admin/events")}
         >
           <h2 className="text-xl font-semibold mb-2">📅 イベント一覧</h2>
           <p>イベントの管理と閲覧</p>
         </div>
         <div
-          className="border rounded p-4 shadow hover:bg-gray-50 cursor-pointer"
+          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
           onClick={() => router.push("/admin/users")}
         >
           <h2 className="text-xl font-semibold mb-2">👤 ユーザー一覧</h2>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -147,7 +147,7 @@ export default function UserListPage() {
       </Link>
       <h1 className="text-2xl font-bold mb-4">全ユーザー予約一覧</h1>
 
-      <table className="w-full border text-sm">
+      <table className="w-full border text-sm shadow-md bg-white">
         <thead>
           <tr className="bg-gray-100">
             <th className="border px-2 py-1">名前</th>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,7 @@ export default function HomePage() {
           {events.map((event) => (
             <div
               key={event.id}
-              className="flex flex-col md:flex-row justify-between border-b pb-6 gap-4"
+              className="flex flex-col md:flex-row justify-between gap-4 p-4 border rounded-lg shadow-md bg-white"
             >
               <div className="flex-1">
                 <h4 className="text-lg font-semibold mb-1">{event.title}</h4>
@@ -96,10 +96,12 @@ export default function HomePage() {
       </section>
 
       {/* 予約確認へのリンク */}
-      <section className="py-6 bg-gray-100 text-center px-4">
-        <p className="mb-2 font-semibold">すでに予約済みの方はこちら</p>
+      <section className="py-8 bg-amber-50 border-t-4 border-amber-500 text-center px-4 mt-8">
+        <p className="mb-4 text-lg font-semibold text-amber-700">
+          すでに予約済みの方はこちら
+        </p>
         <Link href="/reservations/confirm">
-          <button className="bg-yellow-500 hover:bg-yellow-600 text-white py-2 px-4 rounded">
+          <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
             予約の確認・変更はこちら
           </button>
         </Link>

--- a/app/reservations/confirm/page.tsx
+++ b/app/reservations/confirm/page.tsx
@@ -94,7 +94,7 @@ export default function ReservationConfirmPage() {
   return (
     <main className="p-6 max-w-xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">予約確認・編集</h1>
-      <div className="space-y-2 mb-6">
+      <div className="space-y-2 mb-6 p-4 bg-gray-50 border rounded shadow">
         <input
           type="email"
           placeholder="メールアドレス"
@@ -120,7 +120,7 @@ export default function ReservationConfirmPage() {
       {loading && <p>検索中...</p>}
 
       {reservations.map((r) => (
-        <div key={r.id} className="border p-4 mb-4">
+        <div key={r.id} className="border rounded p-4 mb-4 shadow">
           <p>イベントID: {r.eventId}</p>
           <p>時間枠: {r.seatTime || "時間指定なし"}</p>
           <p>人数: {r.guests}</p>
@@ -138,7 +138,7 @@ export default function ReservationConfirmPage() {
                 )
               )
             }
-            className="border p-1 my-2"
+            className="border p-1 my-2 rounded w-full"
           />
           <input
             type="text"
@@ -153,7 +153,7 @@ export default function ReservationConfirmPage() {
               )
             }
             placeholder="住所（任意）"
-            className="border p-1 my-2 w-full"
+            className="border p-1 my-2 rounded w-full"
           />
           <button
             className="bg-green-600 text-white px-3 py-1 mr-2 rounded"


### PR DESCRIPTION
## Summary
- tweak Home page event cards and highlight the reservation check link
- style the reservation confirm page with cards
- polish admin dashboard and event list cards
- refine admin reservation and user management screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857dc67ebe88324a16d5380e761ba86