### PR TITLE
イベント並び替え機能追加

### DIFF
--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -100,10 +100,20 @@ export default function EditEventPage() {
     }
   };
 
+  const sortSeats = (seats: Seat[]) =>
+    [...seats].sort((a, b) => {
+      if (a.time === TENTATIVE_LABEL) return 1;
+      if (b.time === TENTATIVE_LABEL) return -1;
+      return a.time.localeCompare(b.time);
+    });
+
   const addSeat = () => {
     setForm({
       ...form,
-      seats: [...form.seats, { time: "08:00", capacity: 1, reserved: 0 }],
+      seats: sortSeats([
+        ...form.seats,
+        { time: "08:00", capacity: 1, reserved: 0 },
+      ]),
     });
   };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,31 +14,46 @@ export default function HomePage() {
   useEffect(() => {
     const fetchEvents = async () => {
       const snapshot = await getDocs(collection(db, "events"));
-      const data = snapshot.docs.map((doc) => {
-        const d = doc.data();
-        return {
-          id: doc.id,
-          title: d.title,
-          venue: d.venue,
-          date: d.date?.toDate().toLocaleDateString("ja-JP", {
-            year: "numeric",
-            month: "2-digit",
-            day: "2-digit",
-            weekday: "short",
-          }),
-          cost: d.cost,
-          description: d.description,
-          participants: (d.seats as Seat[] | undefined)?.reduce(
-            (sum: number, seat) => sum + (seat.reserved || 0),
-            0
-          ),
-          capacity: (d.seats as Seat[] | undefined)?.reduce(
-            (sum: number, seat) => sum + (seat.capacity || 0),
-            0
-          ),
-          imageUrl: d.imageUrl || "/event1.jpg",
-        } as EventSummary;
-      });
+      const data = snapshot.docs
+        .map((doc) => {
+          const d = doc.data();
+          return {
+            id: doc.id,
+            title: d.title,
+            venue: d.venue,
+            rawDate: d.date?.toDate() as Date,
+            cost: d.cost,
+            description: d.description,
+            participants: (d.seats as Seat[] | undefined)?.reduce(
+              (sum: number, seat) => sum + (seat.reserved || 0),
+              0
+            ),
+            capacity: (d.seats as Seat[] | undefined)?.reduce(
+              (sum: number, seat) => sum + (seat.capacity || 0),
+              0
+            ),
+            imageUrl: d.imageUrl || "/event1.jpg",
+          };
+        })
+        .sort((a, b) => a.rawDate.getTime() - b.rawDate.getTime())
+        .map((ev) => {
+          return {
+            id: ev.id,
+            title: ev.title,
+            venue: ev.venue,
+            date: ev.rawDate.toLocaleDateString("ja-JP", {
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              weekday: "short",
+            }),
+            cost: ev.cost,
+            description: ev.description,
+            participants: ev.participants,
+            capacity: ev.capacity,
+            imageUrl: ev.imageUrl,
+          } as EventSummary;
+        });
       setEvents(data);
     };
     fetchEvents();


### PR DESCRIPTION
## Summary
- イベント作成画面で時間枠追加時に自動ソート
- トップページのイベント表示を開催日順に

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c071253c883249f0a5e9c5b145e1b