### PR TITLE
Hide top image settings link

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -24,13 +24,6 @@ export default function AdminDashboard() {
           <h2 className="text-xl font-semibold mb-2">👤 ユーザー一覧</h2>
           <p>ユーザーの管理と閲覧</p>
         </div>
-        <div
-          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
-          onClick={() => router.push("/admin/top-image")}
-        >
-          <h2 className="text-xl font-semibold mb-2">🖼️ トップページ画像設定</h2>
-          <p>トップページ画像の変更</p>
-        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- hide Top Image management section on admin dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c1d4c8c0c83249670170685019727