### PR TITLE
Add greeting section editable in admin2

### DIFF
--- a/app/admin2/greeting/page.tsx
+++ b/app/admin2/greeting/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import AdminGreetingSettings from "@/components/AdminGreetingSettings";
+import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
+
+export default function GreetingPage() {
+  return (
+    <main className="p-6 max-w-xl mx-auto">
+      <LinkBackToAdmin2Top />
+      <AdminGreetingSettings />
+    </main>
+  );
+}

--- a/app/admin2/page.tsx
+++ b/app/admin2/page.tsx
@@ -17,6 +17,13 @@ export default function AdminDashboard() {
           <h2 className="text-xl font-semibold mb-2">🖼 トップ画像設定</h2>
           <p>サイトのトップページに表示する画像を設定します</p>
         </div>
+        <div
+          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
+          onClick={() => router.push("/admin2/greeting")}
+        >
+          <h2 className="text-xl font-semibold mb-2">💬 ごあいさつ設定</h2>
+          <p>トップページのごあいさつ文と画像を設定します</p>
+        </div>
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,13 +10,20 @@ import type { EventSummary, Seat } from "@/types";
 export default function HomePage() {
   const [events, setEvents] = useState<EventSummary[]>([]);
   const [topImageUrl, setTopImageUrl] = useState("/hero-matcha.png");
+  const [greetingText, setGreetingText] = useState(
+    "の度、お茶会へ参加される皆様の利便性を考慮し、茶会予約のサイトの立ち上げをいたしました。茶会予約参加の登録をはじめ、茶会のご案内や過去の茶会のご紹介などサイトを通じて発信して参ります。\n皆様の役に立つツールとしてご活用いただければ幸いです。どうぞ、宜しくお願い致します。\n石州流野村派　代表\n悠瓢庵　堀 一孝"
+  );
+  const [greetingImageUrl, setGreetingImageUrl] = useState("");
 
   useEffect(() => {
-    const fetchTopImage = async () => {
+    const fetchSiteSettings = async () => {
       const ref = doc(db, "settings", "site");
       const snap = await getDoc(ref);
-      if (snap.exists() && snap.data().heroImageUrl) {
-        setTopImageUrl(snap.data().heroImageUrl);
+      if (snap.exists()) {
+        const data = snap.data();
+        if (data.heroImageUrl) setTopImageUrl(data.heroImageUrl);
+        if (data.greetingText) setGreetingText(data.greetingText);
+        if (data.greetingImageUrl) setGreetingImageUrl(data.greetingImageUrl);
       }
     };
 
@@ -65,7 +72,7 @@ export default function HomePage() {
       setEvents(data);
     };
     fetchEvents();
-    fetchTopImage();
+    fetchSiteSettings();
   }, []);
 
   return (
@@ -79,6 +86,18 @@ export default function HomePage() {
           石州流野村派
         </h1>
         <p className="text-xl sm:text-2xl drop-shadow">茶会行事 予約サイト</p>
+      </section>
+
+      {/* ごあいさつセクション */}
+      <section className="py-8 max-w-5xl mx-auto px-4 text-center">
+        {greetingImageUrl && (
+          <img
+            src={greetingImageUrl}
+            alt="ごあいさつ"
+            className="w-full mb-4 rounded"
+          />
+        )}
+        <p className="whitespace-pre-line text-lg">{greetingText}</p>
       </section>
 
       {/* イベント一覧セクション */}

--- a/components/AdminGreetingSettings.tsx
+++ b/components/AdminGreetingSettings.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { db, storage } from "@/lib/firebase";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
+
+export default function AdminGreetingSettings() {
+  const [text, setText] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const refSite = doc(db, "settings", "site");
+      const snap = await getDoc(refSite);
+      if (snap.exists()) {
+        const data = snap.data();
+        setText(data.greetingText || "");
+        setImageUrl(data.greetingImageUrl || "");
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleFileSelect = () => {
+    inputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setUploading(true);
+    setProgress(0);
+
+    try {
+      const storageRef = ref(storage, `greeting-images/${file.name}`);
+      const uploadTask = uploadBytesResumable(storageRef, file);
+
+      uploadTask.on(
+        "state_changed",
+        (snapshot) => {
+          setProgress((snapshot.bytesTransferred / snapshot.totalBytes) * 100);
+        },
+        (error) => {
+          console.error(error);
+          alert("アップロードに失敗しました");
+          setUploading(false);
+        },
+        async () => {
+          const downloadUrl = await getDownloadURL(uploadTask.snapshot.ref);
+          await setDoc(
+            doc(db, "settings", "site"),
+            { greetingImageUrl: downloadUrl },
+            { merge: true }
+          );
+          setImageUrl(downloadUrl);
+          setUploading(false);
+          setFile(null);
+          setProgress(0);
+          alert("画像をアップロードし、URLを保存しました！");
+        }
+      );
+    } catch (err) {
+      console.error(err);
+      alert("アップロードでエラーが発生しました");
+      setUploading(false);
+    }
+  };
+
+  const handleSaveText = async () => {
+    try {
+      await setDoc(
+        doc(db, "settings", "site"),
+        { greetingText: text },
+        { merge: true }
+      );
+      alert("ごあいさつを保存しました！");
+    } catch (err) {
+      console.error(err);
+      alert("保存に失敗しました");
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">ごあいさつ設定</h1>
+
+      {imageUrl && (
+        <img src={imageUrl} alt="ごあいさつ画像" className="w-full mb-4 rounded" />
+      )}
+
+      <div className="flex items-center gap-4 mb-4">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          ref={inputRef}
+          className="hidden"
+        />
+        <button
+          type="button"
+          onClick={handleFileSelect}
+          className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded shadow"
+        >
+          ファイルを選択
+        </button>
+        {file && <span className="truncate max-w-xs">{file.name}</span>}
+      </div>
+
+      <button
+        onClick={handleUpload}
+        disabled={!file || uploading}
+        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded disabled:opacity-50 mb-6"
+      >
+        {uploading ? `アップロード中...${progress.toFixed(0)}%` : "画像をアップロードして設定"}
+      </button>
+
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        className="w-full h-40 p-2 border rounded mb-4"
+        placeholder="ごあいさつ文を入力"
+      />
+
+      <button
+        onClick={handleSaveText}
+        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+      >
+        ごあいさつを保存
+      </button>
+    </div>
+  );
+}

--- a/storage.rules
+++ b/storage.rules
@@ -8,6 +8,9 @@ service firebase.storage {
     match /hero-images/{allPaths=**} {
       allow read, write;
     }
+    match /greeting-images/{allPaths=**} {
+      allow read, write;
+    }
     match /{allPaths=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Summary
- allow uploading greeting text and image from admin2
- show greeting section on the top page
- add Firebase storage rule for greeting images
- default greeting text added for convenience

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688b78dd045083248fca02195f9fe1f3