### PR TITLE
ごあいさつ設定を行単位で装飾可能に

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,13 +5,20 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { db } from "@/lib/firebase";
 import { collection, getDocs, doc, getDoc } from "firebase/firestore";
-import type { EventSummary, Seat } from "@/types";
+import type { EventSummary, Seat, GreetingLine } from "@/types";
 
 export default function HomePage() {
   const [events, setEvents] = useState<EventSummary[]>([]);
   const [topImageUrl, setTopImageUrl] = useState("/hero-matcha.png");
-  const [greetingText, setGreetingText] = useState(
-    "の度、お茶会へ参加される皆様の利便性を考慮し、茶会予約のサイトの立ち上げをいたしました。茶会予約参加の登録をはじめ、茶会のご案内や過去の茶会のご紹介などサイトを通じて発信して参ります。\n皆様の役に立つツールとしてご活用いただければ幸いです。どうぞ、宜しくお願い致します。\n石州流野村派　代表\n悠瓢庵　堀 一孝"
+  const defaultGreeting =
+    "の度、お茶会へ参加される皆様の利便性を考慮し、茶会予約のサイトの立ち上げをいたしました。茶会予約参加の登録をはじめ、茶会のご案内や過去の茶会のご紹介などサイトを通じて発信して参ります。\n皆様の役に立つツールとしてご活用いただければ幸いです。どうぞ、宜しくお願い致します。\n石州流野村派　代表\n悠瓢庵　堀 一孝";
+  const [greetingLines, setGreetingLines] = useState<GreetingLine[]>(
+    defaultGreeting.split("\n").map((t) => ({
+      text: t,
+      align: "left",
+      color: "#000000",
+      font: "serif",
+    }))
   );
   const [greetingImageUrl, setGreetingImageUrl] = useState("");
 
@@ -22,7 +29,19 @@ export default function HomePage() {
       if (snap.exists()) {
         const data = snap.data();
         if (data.heroImageUrl) setTopImageUrl(data.heroImageUrl);
-        if (data.greetingText) setGreetingText(data.greetingText);
+        if (data.greetingLines) {
+          setGreetingLines(data.greetingLines as GreetingLine[]);
+        } else if (data.greetingText) {
+          const split = (data.greetingText as string).split("\n");
+          setGreetingLines(
+            split.map((t: string) => ({
+              text: t,
+              align: "left",
+              color: "#000000",
+              font: "serif",
+            }))
+          );
+        }
         if (data.greetingImageUrl) setGreetingImageUrl(data.greetingImageUrl);
       }
     };
@@ -89,7 +108,7 @@ export default function HomePage() {
       </section>
 
       {/* ごあいさつセクション */}
-      <section className="py-8 max-w-5xl mx-auto px-4 text-center">
+      <section className="py-8 max-w-5xl mx-auto px-4">
         {greetingImageUrl && (
           <img
             src={greetingImageUrl}
@@ -97,7 +116,30 @@ export default function HomePage() {
             className="w-full mb-4 rounded"
           />
         )}
-        <p className="whitespace-pre-line text-lg">{greetingText}</p>
+        {greetingLines &&
+          greetingLines.map((line, idx) => {
+            const alignClass =
+              line.align === "center"
+                ? "text-center"
+                : line.align === "right"
+                ? "text-right"
+                : "text-left";
+            const fontClass =
+              line.font === "sans"
+                ? "font-sans"
+                : line.font === "mono"
+                ? "font-mono"
+                : "font-serif";
+            return (
+              <p
+                key={idx}
+                className={`text-lg ${alignClass} ${fontClass}`}
+                style={{ color: line.color }}
+              >
+                {line.text}
+              </p>
+            );
+          })}
       </section>
 
       {/* イベント一覧セクション */}

--- a/types.ts
+++ b/types.ts
@@ -41,3 +41,10 @@ export interface Reservation {
   createdAt: string;
   password?: string;
 }
+
+export interface GreetingLine {
+  text: string;
+  align: "left" | "center" | "right";
+  color: string;
+  font: "serif" | "sans" | "mono";
+}


### PR DESCRIPTION
## 概要
- `types.ts` に `GreetingLine` 型を追加
- 管理画面からごあいさつ文を行単位で入力できるよう更新
  - 行ごとに左/中央/右揃え、フォント、文字色を設定可能
- トップページで `greetingLines` を読み込みスタイルに従って表示
- 既存の `greetingText` が保存されている場合は自動的に行データへ変換

## テスト
- `npm run lint` を実行し警告のみで終了することを確認
- `npm run build` はフォント取得に失敗しビルドエラー


------
https://chatgpt.com/codex/tasks/task_e_688b7b56f8688324b3a51a75878b2410