### PR TITLE
Update Firebase storage paths

### DIFF
--- a/components/AdminGreetingSettings.tsx
+++ b/components/AdminGreetingSettings.tsx
@@ -59,7 +59,7 @@ export default function AdminGreetingSettings() {
     setProgress(0);
 
     try {
-      const storageRef = ref(storage, `greeting-images/${file.name}`);
+      const storageRef = ref(storage, `images/greeting-images/${file.name}`);
       const uploadTask = uploadBytesResumable(storageRef, file);
 
       uploadTask.on(

--- a/components/AdminTopImageSettings.tsx
+++ b/components/AdminTopImageSettings.tsx
@@ -40,7 +40,7 @@ export default function AdminTopImageSettings() {
     setProgress(0);
 
     try {
-      const storageRef = ref(storage, `hero-images/${file.name}`);
+      const storageRef = ref(storage, `images/hero-images/${file.name}`);
       const uploadTask = uploadBytesResumable(storageRef, file);
 
       uploadTask.on(

--- a/storage.rules
+++ b/storage.rules
@@ -5,12 +5,12 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
-    match /hero-images/{allPaths=**} {
+    // images フォルダ以下は全て読み書き可能
+    match /images/{allPaths=**} {
       allow read, write;
     }
-    match /greeting-images/{allPaths=**} {
-      allow read, write;
-    }
+
+    // その他は読み書き禁止
     match /{allPaths=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Summary
- update Firebase `storage.rules` to use `images` root folder
- adjust upload paths for admin image settings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b815197f883249ff50ae1d9209ede