### PR TITLE
Use Noto Serif JP site-wide

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-serif: var(--font-noto-serif);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +21,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-serif), serif;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Noto_Serif_JP } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const notoSerif = Noto_Serif_JP({
+  variable: "--font-noto-serif",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["400", "700"],
 });
 
 export const metadata: Metadata = {
@@ -23,10 +19,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html lang="ja">
+      <body className={`${notoSerif.variable} font-serif antialiased`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- switch to `Noto Serif JP` font
- set page language to Japanese

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b837d7fe083248468f5e34dda1ecf