### PR TITLE
Add Storage CORS config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,31 @@ FROM_EMAIL=noreply@sustirel.com
 ```
 
 By default the sender address is `onboarding@resend.dev`, but you can override it using the `FROM_EMAIL` variable as shown above.
+
+## Firebase Storage の CORS 設定
+
+`sekishu-nomura-ochakai.sustirel.com` からの画像アップロードを許可するには、以下の手順で CORS 設定を行います。
+
+1. `cors.json` を編集し、許可するオリジンを追加します。
+
+```json
+[
+  {
+    "origin": [
+      "http://localhost:3000",
+      "https://sekishu-nomura-ochakai.sustirel.com"
+    ],
+    "method": ["GET", "POST", "PUT", "DELETE"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": ["Content-Type"]
+  }
+]
+```
+
+2. `gsutil` を使って Firebase Storage に設定を反映します。
+
+```bash
+npm run set-cors
+```
+
+このコマンドは内部で `gsutil cors set cors.json gs://ochakai-reserve.appspot.com` を実行します。

--- a/cors.json
+++ b/cors.json
@@ -1,9 +1,12 @@
 [
-    {
-      "origin": ["http://localhost:3000"],
-      "method": ["GET", "POST", "PUT", "DELETE"],
-      "maxAgeSeconds": 3600,
-      "responseHeader": ["Content-Type"]
-    }
-  ]
+  {
+    "origin": [
+      "http://localhost:3000",
+      "https://sekishu-nomura-ochakai.sustirel.com"
+    ],
+    "method": ["GET", "POST", "PUT", "DELETE"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": ["Content-Type"]
+  }
+]
   

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "sekishu-reservation",
   "version": "0.1.0",
   "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
+    "scripts": {
+      "dev": "next dev",
+      "build": "next build",
+      "start": "next start",
+      "lint": "next lint",
+      "set-cors": "gsutil cors set cors.json gs://ochakai-reserve.appspot.com"
+    },
   "dependencies": {
     "date-fns": "^4.1.0",
     "firebase": "^11.6.1",


### PR DESCRIPTION
## Summary
- allow `sekishu-nomura-ochakai.sustirel.com` in `cors.json`
- add `set-cors` npm script
- document how to update Firebase Storage CORS settings

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b89b8e49483249d3d06f46e9dccdf