### PR TITLE
Add Firebase image uploader and integrate with admin

### DIFF
--- a/lib/uploadImage.ts
+++ b/lib/uploadImage.ts
@@ -1,0 +1,42 @@
+import { storage } from "./firebase";
+import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
+
+/**
+ * Firebase Storage へ画像をアップロードしてURLを取得します
+ * @param file アップロードする画像ファイル
+ * @param path Storage 上の保存パス (例: `images/greeting.jpg`)
+ * @param onProgress 進捗を取得したい場合にコールバックを指定
+ * @returns ダウンロードURL
+ */
+export async function uploadImage(
+  file: File,
+  path: string,
+  onProgress?: (progress: number) => void
+): Promise<string> {
+  const storageRef = ref(storage, path);
+  const uploadTask = uploadBytesResumable(storageRef, file);
+
+  return new Promise((resolve, reject) => {
+    uploadTask.on(
+      "state_changed",
+      (snapshot) => {
+        if (onProgress) {
+          const pct =
+            (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+          onProgress(pct);
+        }
+      },
+      (error) => {
+        reject(error);
+      },
+      async () => {
+        try {
+          const url = await getDownloadURL(uploadTask.snapshot.ref);
+          resolve(url);
+        } catch (err) {
+          reject(err);
+        }
+      }
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add `uploadImage` helper to encapsulate Firebase Storage uploads
- update admin greeting settings page to use the new helper

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_688b95c246008324bb577264b1c5fc6f