### PR TITLE
Add events and blog pages

### DIFF
--- a/app/admin2/letters/page.tsx
+++ b/app/admin2/letters/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import AdminBlogEditor from "@/components/AdminBlogEditor";
+import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
+
+export default function LettersAdminPage() {
+  return (
+    <main className="p-6 max-w-xl mx-auto">
+      <LinkBackToAdmin2Top />
+      <AdminBlogEditor
+        collectionName="letters"
+        heading="通信"
+        storagePath="images/letters"
+      />
+    </main>
+  );
+}

--- a/app/admin2/page.tsx
+++ b/app/admin2/page.tsx
@@ -24,6 +24,20 @@ export default function AdminDashboard() {
           <h2 className="text-xl font-semibold mb-2">💬 ごあいさつ設定</h2>
           <p>トップページのごあいさつ文と画像を設定します</p>
         </div>
+        <div
+          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
+          onClick={() => router.push("/admin2/past-posts")}
+        >
+          <h2 className="text-xl font-semibold mb-2">📜 過去の茶会紹介</h2>
+          <p>過去の茶会を紹介する記事を投稿します</p>
+        </div>
+        <div
+          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
+          onClick={() => router.push("/admin2/letters")}
+        >
+          <h2 className="text-xl font-semibold mb-2">✉ 通信</h2>
+          <p>通信ページの記事を投稿します</p>
+        </div>
       </div>
     </main>
   );

--- a/app/admin2/past-posts/page.tsx
+++ b/app/admin2/past-posts/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import AdminBlogEditor from "@/components/AdminBlogEditor";
+import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
+
+export default function PastPostsAdminPage() {
+  return (
+    <main className="p-6 max-w-xl mx-auto">
+      <LinkBackToAdmin2Top />
+      <AdminBlogEditor
+        collectionName="pastPosts"
+        heading="過去の茶会紹介"
+        storagePath="images/past-posts"
+      />
+    </main>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { db } from "@/lib/firebase";
+import { collection, getDocs } from "firebase/firestore";
+import type { EventSummary, Seat } from "@/types";
+import LinkBackToHome from "@/components/LinkBackToHome";
+
+export default function EventsPage() {
+  const [events, setEvents] = useState<EventSummary[]>([]);
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      const snapshot = await getDocs(collection(db, "events"));
+      const data = snapshot.docs
+        .map((doc) => {
+          const d = doc.data();
+          return {
+            id: doc.id,
+            title: d.title,
+            venue: d.venue,
+            rawDate: d.date?.toDate() as Date,
+            cost: d.cost,
+            description: d.description,
+            participants: (d.seats as Seat[] | undefined)?.reduce(
+              (sum: number, seat) => sum + (seat.reserved || 0),
+              0
+            ),
+            capacity: (d.seats as Seat[] | undefined)?.reduce(
+              (sum: number, seat) => sum + (seat.capacity || 0),
+              0
+            ),
+            imageUrl: d.imageUrl || "/event1.jpg",
+          };
+        })
+        .sort((a, b) => a.rawDate.getTime() - b.rawDate.getTime())
+        .map((ev) => {
+          return {
+            id: ev.id,
+            title: ev.title,
+            venue: ev.venue,
+            date: ev.rawDate.toLocaleDateString("ja-JP", {
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              weekday: "short",
+            }),
+            cost: ev.cost,
+            description: ev.description,
+            participants: ev.participants,
+            capacity: ev.capacity,
+            imageUrl: ev.imageUrl,
+          } as EventSummary;
+        });
+      setEvents(data);
+    };
+    fetchEvents();
+  }, []);
+
+  return (
+    <main className="p-6 max-w-5xl mx-auto">
+      <LinkBackToHome />
+      <h1 className="text-2xl font-bold text-center mb-6">お茶会のご案内</h1>
+      <div className="space-y-8">
+        {events.map((event) => (
+          <div
+            key={event.id}
+            className="flex flex-col md:flex-row items-center gap-6 p-6 border rounded-lg shadow-lg bg-white hover:shadow-xl transition-shadow"
+          >
+            <div className="flex-1">
+              <h2 className="text-xl font-bold mb-2">{event.title}</h2>
+              <p className="mb-1 font-semibold">
+                会場: <span className="font-normal">{event.venue}</span>
+              </p>
+              <p className="mb-1 font-semibold">
+                日時: <span className="font-normal">{event.date}</span>
+              </p>
+              <p className="mb-1 font-semibold">
+                参加費用: <span className="font-normal">{event.cost}円</span>
+              </p>
+              <p className="mb-3 font-semibold">
+                参加人数:
+                <span className="font-normal">
+                  {event.participants}/{event.capacity}人
+                </span>
+              </p>
+              <p className="mb-4">{event.description}</p>
+              <Link href={`/events/${event.id}`}>
+                <button className="w-32 mx-auto block bg-yellow-500 hover:bg-yellow-600 text-white py-2 rounded shadow transition-colors">
+                  予約する
+                </button>
+              </Link>
+            </div>
+            <div className="w-full md:w-1/3">
+              <div className="relative w-full h-48 md:h-64 rounded overflow-hidden">
+                <Image
+                  src={event.imageUrl}
+                  alt={event.title}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 33vw"
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { db } from "@/lib/firebase";
-import { collection, getDocs, doc, getDoc } from "firebase/firestore";
-import type { EventSummary, Seat, GreetingLine } from "@/types";
+import { doc, getDoc } from "firebase/firestore";
+import type { GreetingLine } from "@/types";
 
 export default function HomePage() {
-  const [events, setEvents] = useState<EventSummary[]>([]);
   const [topImageUrl, setTopImageUrl] = useState("/hero-matcha.png");
   const defaultGreeting =
     "の度、お茶会へ参加される皆様の利便性を考慮し、茶会予約のサイトの立ち上げをいたしました。茶会予約参加の登録をはじめ、茶会のご案内や過去の茶会のご紹介などサイトを通じて発信して参ります。\n皆様の役に立つツールとしてご活用いただければ幸いです。どうぞ、宜しくお願い致します。\n石州流野村派　代表\n悠瓢庵　堀 一孝";
@@ -46,51 +44,6 @@ export default function HomePage() {
       }
     };
 
-    const fetchEvents = async () => {
-      const snapshot = await getDocs(collection(db, "events"));
-      const data = snapshot.docs
-        .map((doc) => {
-          const d = doc.data();
-          return {
-            id: doc.id,
-            title: d.title,
-            venue: d.venue,
-            rawDate: d.date?.toDate() as Date,
-            cost: d.cost,
-            description: d.description,
-            participants: (d.seats as Seat[] | undefined)?.reduce(
-              (sum: number, seat) => sum + (seat.reserved || 0),
-              0
-            ),
-            capacity: (d.seats as Seat[] | undefined)?.reduce(
-              (sum: number, seat) => sum + (seat.capacity || 0),
-              0
-            ),
-            imageUrl: d.imageUrl || "/event1.jpg",
-          };
-        })
-        .sort((a, b) => a.rawDate.getTime() - b.rawDate.getTime())
-        .map((ev) => {
-          return {
-            id: ev.id,
-            title: ev.title,
-            venue: ev.venue,
-            date: ev.rawDate.toLocaleDateString("ja-JP", {
-              year: "numeric",
-              month: "2-digit",
-              day: "2-digit",
-              weekday: "short",
-            }),
-            cost: ev.cost,
-            description: ev.description,
-            participants: ev.participants,
-            capacity: ev.capacity,
-            imageUrl: ev.imageUrl,
-          } as EventSummary;
-        });
-      setEvents(data);
-    };
-    fetchEvents();
     fetchSiteSettings();
   }, []);
 
@@ -142,43 +95,24 @@ export default function HomePage() {
           })}
       </section>
 
-      {/* イベント一覧セクション */}
-      <section className="py-12 mb-8 max-w-5xl mx-auto px-4 bg-amber-50 border-b-4 border-amber-500 rounded">
-        <h3 className="text-lg font-semibold text-amber-700 text-center mb-6">お茶会のご案内</h3>
-        <div className="space-y-8">
-          {events.map((event) => (
-            <div
-              key={event.id}
-              className="flex flex-col md:flex-row items-center gap-6 p-6 border rounded-lg shadow-lg bg-white hover:shadow-xl transition-shadow"
-            >
-              <div className="flex-1">
-                <h4 className="text-xl font-bold mb-2">{event.title}</h4>
-                <p className="mb-1 font-semibold">会場: <span className="font-normal">{event.venue}</span></p>
-                <p className="mb-1 font-semibold">日時: <span className="font-normal">{event.date}</span></p>
-                <p className="mb-1 font-semibold">参加費用: <span className="font-normal">{event.cost}円</span></p>
-                <p className="mb-3 font-semibold">
-                  参加人数: <span className="font-normal">{event.participants}/{event.capacity}人</span>
-                </p>
-                <p className="mb-4">{event.description}</p>
-                <Link href={`/events/${event.id}`}>
-                  <button className="w-32 mx-auto block bg-yellow-500 hover:bg-yellow-600 text-white py-2 rounded shadow transition-colors">
-                    予約する
-                  </button>
-                </Link>
-              </div>
-              <div className="w-full md:w-1/3">
-                <div className="relative w-full h-48 md:h-64 rounded overflow-hidden">
-                  <Image
-                    src={event.imageUrl}
-                    alt={event.title}
-                    fill
-                    className="object-cover"
-                    sizes="(max-width: 768px) 100vw, 33vw"
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
+      {/* 各ページへのリンク */}
+      <section className="py-12 mb-8 max-w-5xl mx-auto px-4 text-center">
+        <div className="flex flex-col sm:flex-row justify-center gap-4">
+          <Link href="/events">
+            <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
+              お茶会のご案内
+            </button>
+          </Link>
+          <Link href="/posts/past">
+            <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
+              過去の茶会紹介
+            </button>
+          </Link>
+          <Link href="/posts/letters">
+            <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
+              通信
+            </button>
+          </Link>
         </div>
       </section>
 

--- a/app/posts/letters/page.tsx
+++ b/app/posts/letters/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { db } from "@/lib/firebase";
+import { collection, getDocs, query, orderBy } from "firebase/firestore";
+import type { BlogPost } from "@/types";
+import LinkBackToHome from "@/components/LinkBackToHome";
+
+export default function LettersPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      const q = query(collection(db, "letters"), orderBy("createdAt", "desc"));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({ id: doc.id, ...(doc.data() as Omit<BlogPost,"id">) }));
+      setPosts(data);
+    };
+    fetchPosts();
+  }, []);
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto">
+      <LinkBackToHome />
+      <h1 className="text-2xl font-bold mb-6 text-center">通信</h1>
+      <div className="space-y-8">
+        {posts.map((post) => (
+          <article key={post.id} className="border p-4 rounded shadow bg-white">
+            <h2 className="text-xl font-semibold mb-2">{post.title}</h2>
+            {post.imageUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={post.imageUrl} alt={post.title} className="mb-2 w-full rounded" />
+            )}
+            <p className="whitespace-pre-wrap">{post.body}</p>
+            <p className="text-right text-sm text-gray-500 mt-2">
+              {new Date(post.createdAt).toLocaleDateString("ja-JP")}
+            </p>
+          </article>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/posts/past/page.tsx
+++ b/app/posts/past/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { db } from "@/lib/firebase";
+import { collection, getDocs, query, orderBy } from "firebase/firestore";
+import type { BlogPost } from "@/types";
+import LinkBackToHome from "@/components/LinkBackToHome";
+
+export default function PastPostsPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      const q = query(collection(db, "pastPosts"), orderBy("createdAt", "desc"));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({ id: doc.id, ...(doc.data() as Omit<BlogPost,"id">) }));
+      setPosts(data);
+    };
+    fetchPosts();
+  }, []);
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto">
+      <LinkBackToHome />
+      <h1 className="text-2xl font-bold mb-6 text-center">過去の茶会紹介</h1>
+      <div className="space-y-8">
+        {posts.map((post) => (
+          <article key={post.id} className="border p-4 rounded shadow bg-white">
+            <h2 className="text-xl font-semibold mb-2">{post.title}</h2>
+            {post.imageUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={post.imageUrl} alt={post.title} className="mb-2 w-full rounded" />
+            )}
+            <p className="whitespace-pre-wrap">{post.body}</p>
+            <p className="text-right text-sm text-gray-500 mt-2">
+              {new Date(post.createdAt).toLocaleDateString("ja-JP")}
+            </p>
+          </article>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { db } from "@/lib/firebase";
+import { collection, addDoc, getDocs, query, orderBy } from "firebase/firestore";
+import { uploadImage } from "@/lib/uploadImage";
+import type { BlogPost } from "@/types";
+
+interface Props {
+  collectionName: string;
+  heading: string;
+  storagePath: string;
+}
+
+export default function AdminBlogEditor({ collectionName, heading, storagePath }: Props) {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const fetchPosts = async () => {
+    const q = query(collection(db, collectionName), orderBy("createdAt", "desc"));
+    const snapshot = await getDocs(q);
+    const data = snapshot.docs.map((doc) => ({ id: doc.id, ...(doc.data() as Omit<BlogPost,"id">) }));
+    setPosts(data);
+  };
+
+  useEffect(() => {
+    fetchPosts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSubmit = async () => {
+    setUploading(true);
+    let imageUrl = "";
+    try {
+      if (file) {
+        imageUrl = await uploadImage(file, `${storagePath}/${file.name}`, setProgress);
+      }
+      await addDoc(collection(db, collectionName), {
+        title,
+        body,
+        imageUrl,
+        createdAt: new Date().toISOString(),
+      });
+      setTitle("");
+      setBody("");
+      setFile(null);
+      setProgress(0);
+      await fetchPosts();
+      alert("投稿を保存しました");
+    } catch (err) {
+      console.error(err);
+      alert("保存に失敗しました");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{heading}</h1>
+      <div className="mb-4">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="タイトル"
+          className="border p-2 w-full mb-2"
+        />
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="本文"
+          className="border p-2 w-full h-40 mb-2"
+        />
+        <input
+          type="file"
+          accept="image/*"
+          ref={inputRef}
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          className="mb-2"
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={uploading}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+        >
+          {uploading ? `アップロード中...${progress.toFixed(0)}%` : "投稿する"}
+        </button>
+      </div>
+      <div className="space-y-4">
+        {posts.map((post) => (
+          <div key={post.id} className="border p-3 rounded bg-white">
+            <h2 className="font-semibold">{post.title}</h2>
+            <p className="text-sm text-gray-500 mb-2">
+              {new Date(post.createdAt).toLocaleDateString("ja-JP")}
+            </p>
+            {post.imageUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={post.imageUrl} alt="" className="mb-2 w-full rounded" />
+            )}
+            <p className="whitespace-pre-wrap text-sm">{post.body}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/LinkBackToHome.tsx
+++ b/components/LinkBackToHome.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function LinkBackToHome() {
+  return (
+    <Link
+      href="/"
+      className="text-sm text-blue-600 underline hover:text-blue-800 mb-4 block"
+    >
+      ← トップページへ戻る
+    </Link>
+  );
+}

--- a/types.ts
+++ b/types.ts
@@ -48,3 +48,11 @@ export interface GreetingLine {
   color: string;
   font: "serif" | "sans" | "mono";
 }
+
+export interface BlogPost {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  imageUrl?: string;
+}


### PR DESCRIPTION
## Summary
- create EventsPage and link from top
- add blog capabilities for past events and newsletters via Admin2
- show links for new pages on admin dashboard and home
- add helper components for navigation

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Noto Serif JP` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688b9b87b4f4832484406bde7cb591ca