### PR TITLE
Add blog management features

### DIFF
--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -2,7 +2,16 @@
 
 import { useState, useEffect, useRef } from "react";
 import { db } from "@/lib/firebase";
-import { collection, addDoc, getDocs, query, orderBy } from "firebase/firestore";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  updateDoc,
+  deleteDoc,
+  doc,
+} from "firebase/firestore";
 import { uploadImage } from "@/lib/uploadImage";
 import type { BlogPost } from "@/types";
 
@@ -19,10 +28,15 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
   const [file, setFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc");
   const inputRef = useRef<HTMLInputElement>(null);
 
   const fetchPosts = async () => {
-    const q = query(collection(db, collectionName), orderBy("createdAt", "desc"));
+    const q = query(
+      collection(db, collectionName),
+      orderBy("createdAt", sortOrder)
+    );
     const snapshot = await getDocs(q);
     const data = snapshot.docs.map((doc) => ({ id: doc.id, ...(doc.data() as Omit<BlogPost,"id">) }));
     setPosts(data);
@@ -31,27 +45,41 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
   useEffect(() => {
     fetchPosts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [sortOrder]);
 
   const handleSubmit = async () => {
     setUploading(true);
     let imageUrl = "";
     try {
       if (file) {
-        imageUrl = await uploadImage(file, `${storagePath}/${file.name}`, setProgress);
+        imageUrl = await uploadImage(
+          file,
+          `${storagePath}/${file.name}`,
+          setProgress
+        );
       }
-      await addDoc(collection(db, collectionName), {
-        title,
-        body,
-        imageUrl,
-        createdAt: new Date().toISOString(),
-      });
+      if (editingId) {
+        const original = posts.find((p) => p.id === editingId);
+        await updateDoc(doc(db, collectionName, editingId), {
+          title,
+          body,
+          imageUrl: imageUrl || original?.imageUrl || "",
+        });
+      } else {
+        await addDoc(collection(db, collectionName), {
+          title,
+          body,
+          imageUrl,
+          createdAt: new Date().toISOString(),
+        });
+      }
       setTitle("");
       setBody("");
       setFile(null);
       setProgress(0);
+      setEditingId(null);
       await fetchPosts();
-      alert("投稿を保存しました");
+      alert(editingId ? "投稿を更新しました" : "投稿を保存しました");
     } catch (err) {
       console.error(err);
       alert("保存に失敗しました");
@@ -63,6 +91,17 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
   return (
     <div className="p-6 max-w-xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">{heading}</h1>
+      <div className="mb-4 flex items-center space-x-2">
+        <label className="text-sm">並び順:</label>
+        <select
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value as "asc" | "desc")}
+          className="border p-1 text-sm"
+        >
+          <option value="desc">新しい順</option>
+          <option value="asc">古い順</option>
+        </select>
+      </div>
       <div className="mb-4">
         <input
           type="text"
@@ -84,21 +123,70 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
           onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
           className="mb-2"
         />
-        <button
-          onClick={handleSubmit}
-          disabled={uploading}
-          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-        >
-          {uploading ? `アップロード中...${progress.toFixed(0)}%` : "投稿する"}
-        </button>
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={handleSubmit}
+            disabled={uploading}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+          >
+            {uploading
+              ? `アップロード中...${progress.toFixed(0)}%`
+              : editingId
+              ? "更新する"
+              : "投稿する"}
+          </button>
+          {editingId && (
+            <button
+              type="button"
+              className="text-sm underline"
+              onClick={() => {
+                setEditingId(null);
+                setTitle("");
+                setBody("");
+                setFile(null);
+                if (inputRef.current) inputRef.current.value = "";
+              }}
+            >
+              キャンセル
+            </button>
+          )}
+        </div>
       </div>
       <div className="space-y-4">
         {posts.map((post) => (
           <div key={post.id} className="border p-3 rounded bg-white">
-            <h2 className="font-semibold">{post.title}</h2>
-            <p className="text-sm text-gray-500 mb-2">
-              {new Date(post.createdAt).toLocaleDateString("ja-JP")}
-            </p>
+            <div className="flex justify-between items-start">
+              <div>
+                <h2 className="font-semibold">{post.title}</h2>
+                <p className="text-sm text-gray-500 mb-2">
+                  {new Date(post.createdAt).toLocaleDateString("ja-JP")}
+                </p>
+              </div>
+              <div className="space-x-2">
+                <button
+                  className="text-xs text-red-600"
+                  onClick={async () => {
+                    if (confirm("削除してよろしいですか？")) {
+                      await deleteDoc(doc(db, collectionName, post.id));
+                      fetchPosts();
+                    }
+                  }}
+                >
+                  削除
+                </button>
+                <button
+                  className="text-xs text-blue-600"
+                  onClick={() => {
+                    setEditingId(post.id);
+                    setTitle(post.title);
+                    setBody(post.body);
+                    if (inputRef.current) inputRef.current.value = "";
+                  }}
+                >
+                  編集
+                </button>
+              </div>
+            </div>
             {post.imageUrl && (
               // eslint-disable-next-line @next/next/no-img-element
               <img src={post.imageUrl} alt="" className="mb-2 w-full rounded" />

--- a/components/LinkBackToHome.tsx
+++ b/components/LinkBackToHome.tsx
@@ -4,9 +4,21 @@ export default function LinkBackToHome() {
   return (
     <Link
       href="/"
-      className="text-sm text-blue-600 underline hover:text-blue-800 mb-4 block"
+      className="inline-flex items-center text-sm text-blue-600 hover:text-blue-800 mb-4 font-medium"
     >
-      ← トップページへ戻る
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-4 h-4 mr-1"
+      >
+        <path
+          fillRule="evenodd"
+          d="M15.75 19.5a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 010-1.06l7.5-7.5a.75.75 0 011.06 1.06L9.06 12l6.69 6.69a.75.75 0 010 1.06z"
+          clipRule="evenodd"
+        />
+      </svg>
+      トップページへ戻る
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- enable editing and deletion of blog posts
- allow changing sort order in admin posts
- style `トップページへ戻る` link with an icon

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e1266448324be0f33726f6df591