### PR TITLE
通信ページの名称変更とブログ表示改善

### DIFF
--- a/app/admin2/letters/page.tsx
+++ b/app/admin2/letters/page.tsx
@@ -9,7 +9,7 @@ export default function LettersAdminPage() {
       <LinkBackToAdmin2Top />
       <AdminBlogEditor
         collectionName="letters"
-        heading="通信"
+        heading="通信ページ"
         storagePath="images/letters"
       />
     </main>

--- a/app/admin2/page.tsx
+++ b/app/admin2/page.tsx
@@ -35,7 +35,7 @@ export default function AdminDashboard() {
           className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
           onClick={() => router.push("/admin2/letters")}
         >
-          <h2 className="text-xl font-semibold mb-2">✉ 通信</h2>
+          <h2 className="text-xl font-semibold mb-2">✉ 通信ページ</h2>
           <p>通信ページの記事を投稿します</p>
         </div>
       </div>

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     const htmlBody =
       html ||
       `
-        <div style="font-family: sans-serif; line-height: 1.6;">
+        <div style="font-family:'Noto Serif JP', serif; line-height: 1.6;">
           <p>これはテストメールです。</p>
           <p>Resendの設定確認用として送信されました。</p>
         </div>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -120,7 +120,7 @@ export default function EventDetailPage() {
         to: email,
         subject: `${event.title} のご予約完了通知`,
         html: `
-          <div style="font-family:'Hiragino Mincho Pro', serif; line-height:1.8; font-size:16px;">
+          <div style="font-family:'Noto Serif JP', serif; line-height:1.8; font-size:16px;">
             <p>${name} 様</p>
             <p>
               この度は「${event.title}」にお申し込みいただき、誠にありがとうございます。<br/>
@@ -171,7 +171,7 @@ export default function EventDetailPage() {
         subject: `${event.title} の予約が入りました`,
         html: `
           
-          <div style="font-family:sans-serif; line-height:1.6;">
+          <div style="font-family:'Noto Serif JP', serif; line-height:1.6;">
             <p>${name}様から予約がありました。</p>
             <ul>
               <li><strong>イベント:</strong> ${event.title}</li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,16 +77,10 @@ export default function HomePage() {
                 : line.align === "right"
                 ? "text-right"
                 : "text-left";
-            const fontClass =
-              line.font === "sans"
-                ? "font-sans"
-                : line.font === "mono"
-                ? "font-mono"
-                : "font-serif";
             return (
               <p
                 key={idx}
-                className={`text-lg ${alignClass} ${fontClass}`}
+                className={`text-lg ${alignClass} font-serif`}
                 style={{ color: line.color }}
               >
                 {line.text}
@@ -99,30 +93,30 @@ export default function HomePage() {
       <section className="py-12 mb-8 max-w-5xl mx-auto px-4 text-center">
         <div className="flex flex-col sm:flex-row justify-center gap-4">
           <Link href="/events">
-            <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
+            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow">
               お茶会のご案内
             </button>
           </Link>
           <Link href="/posts/past">
-            <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
+            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow">
               過去の茶会紹介
             </button>
           </Link>
           <Link href="/posts/letters">
-            <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow">
-              通信
+            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow">
+              通信ページ
             </button>
           </Link>
         </div>
       </section>
 
       {/* 予約確認セクション */}
-      <section className="py-8 bg-amber-50 border-t-4 border-amber-500 text-center px-4 mt-8 max-w-5xl mx-auto">
-        <p className="mb-4 text-lg font-semibold text-amber-700">
+      <section className="py-8 bg-[#F5F0E6] border-t-4 border-[#C1A46F] text-center px-4 mt-8 max-w-5xl mx-auto">
+        <p className="mb-4 text-lg font-semibold text-[#8B5E3C]">
           すでに予約済みの方はこちら
         </p>
         <Link href="/reservations/confirm">
-          <button className="bg-amber-500 hover:bg-amber-600 text-white py-2 px-6 rounded shadow transition-colors">
+          <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow transition-colors">
             予約の確認・変更はこちら
           </button>
         </Link>

--- a/app/posts/letters/[id]/page.tsx
+++ b/app/posts/letters/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import type { BlogPost } from "@/types";
+import LinkBackToHome from "@/components/LinkBackToHome";
+
+export default function LetterDetailPage() {
+  const { id } = useParams();
+  const [post, setPost] = useState<BlogPost | null>(null);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      if (!id) return;
+      const ref = doc(db, "letters", id as string);
+      const snap = await getDoc(ref);
+      if (snap.exists()) {
+        setPost({ id: snap.id, ...(snap.data() as Omit<BlogPost, "id">) });
+      }
+    };
+    fetchPost();
+  }, [id]);
+
+  if (!post) return <p className="p-6">読み込み中...</p>;
+
+  const date = new Date(post.createdAt).toLocaleDateString("ja-JP");
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto">
+      <LinkBackToHome />
+      {post.imageUrl && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={post.imageUrl}
+          alt={post.title}
+          className="w-full rounded mb-4"
+        />
+      )}
+      <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
+      <div className="whitespace-pre-wrap text-gray-700 mb-4">{post.body}</div>
+      <p className="text-right text-sm text-gray-500">{date}</p>
+    </main>
+  );
+}
+

--- a/app/posts/letters/page.tsx
+++ b/app/posts/letters/page.tsx
@@ -23,10 +23,10 @@ export default function LettersPage() {
   return (
     <main className="p-6 max-w-5xl mx-auto">
       <LinkBackToHome />
-      <h1 className="text-2xl font-bold mb-6 text-center">通信</h1>
+      <h1 className="text-2xl font-bold mb-6 text-center">通信ページ</h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => (
-          <BlogCard key={post.id} post={post} />
+          <BlogCard key={post.id} post={post} href={`/posts/letters/${post.id}`} />
         ))}
       </div>
     </main>

--- a/app/posts/past/[id]/page.tsx
+++ b/app/posts/past/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import type { BlogPost } from "@/types";
+import LinkBackToHome from "@/components/LinkBackToHome";
+
+export default function PastPostDetailPage() {
+  const { id } = useParams();
+  const [post, setPost] = useState<BlogPost | null>(null);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      if (!id) return;
+      const ref = doc(db, "pastPosts", id as string);
+      const snap = await getDoc(ref);
+      if (snap.exists()) {
+        setPost({ id: snap.id, ...(snap.data() as Omit<BlogPost, "id">) });
+      }
+    };
+    fetchPost();
+  }, [id]);
+
+  if (!post) return <p className="p-6">読み込み中...</p>;
+
+  const date = new Date(post.createdAt).toLocaleDateString("ja-JP");
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto">
+      <LinkBackToHome />
+      {post.imageUrl && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={post.imageUrl}
+          alt={post.title}
+          className="w-full rounded mb-4"
+        />
+      )}
+      <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
+      <div className="whitespace-pre-wrap text-gray-700 mb-4">{post.body}</div>
+      <p className="text-right text-sm text-gray-500">{date}</p>
+    </main>
+  );
+}
+

--- a/app/posts/past/page.tsx
+++ b/app/posts/past/page.tsx
@@ -26,7 +26,7 @@ export default function PastPostsPage() {
       <h1 className="text-2xl font-bold mb-6 text-center">過去の茶会紹介</h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => (
-          <BlogCard key={post.id} post={post} />
+          <BlogCard key={post.id} post={post} href={`/posts/past/${post.id}`} />
         ))}
       </div>
     </main>

--- a/components/BlogCard.tsx
+++ b/components/BlogCard.tsx
@@ -1,13 +1,17 @@
+import Link from "next/link";
 import type { BlogPost } from "@/types";
 
 interface Props {
   post: BlogPost;
+  href: string;
 }
 
-export default function BlogCard({ post }: Props) {
+export default function BlogCard({ post, href }: Props) {
   const date = new Date(post.createdAt).toLocaleDateString("ja-JP");
+  const preview =
+    post.body.length > 60 ? post.body.slice(0, 60) + "..." : post.body;
   return (
-    <article className="rounded-lg overflow-hidden shadow-lg bg-white hover:shadow-xl transition-shadow">
+    <Link href={href} className="block rounded-lg overflow-hidden shadow-lg bg-white hover:shadow-xl transition-shadow">
       {post.imageUrl && (
         <div className="h-48 w-full overflow-hidden">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -20,9 +24,9 @@ export default function BlogCard({ post }: Props) {
       )}
       <div className="p-6">
         <h2 className="text-2xl font-bold mb-2">{post.title}</h2>
-        <p className="whitespace-pre-wrap text-gray-700">{post.body}</p>
+        <p className="whitespace-pre-wrap text-gray-700">{preview}</p>
         <p className="text-right text-sm text-gray-500 mt-4">{date}</p>
       </div>
-    </article>
+    </Link>
   );
 }


### PR DESCRIPTION
## 概要
- "通信" を "通信ページ" に名称変更
- 過去の茶会紹介と通信ページにブログ風のカード表示と詳細ページを追加
- フォントをNoto Serif JPに統一し、ボタン類のカラーを茶色系に変更

## テスト
- `npm test` (スクリプト未定義のため失敗)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68917dcd05188324aef5dd236815ae57