### PR TITLE
フォントの統一とイベントページのボタン色修正

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -208,7 +208,7 @@ export default function EventDetailPage() {
   if (!event) return <p className="p-6">読み込み中...</p>;
 
   return (
-    <main className="p-6 max-w-xl mx-auto">
+    <main className="p-6 max-w-xl mx-auto font-serif">
       {event.imageUrl && (
         <div className="mb-4">
           <img src={event.imageUrl} alt={event.title} className="w-full rounded" />
@@ -301,7 +301,7 @@ export default function EventDetailPage() {
         </div>
         <button
           type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded w-full"
+          className="bg-blue-600 text-white px-4 py-2 rounded w-full font-serif"
         >
           予約する
         </button>
@@ -321,14 +321,14 @@ export default function EventDetailPage() {
             <div className="flex gap-4 pt-2">
               <button
                 type="button"
-                className="bg-gray-500 text-white px-4 py-2 rounded flex-1"
+                className="bg-gray-500 text-white px-4 py-2 rounded flex-1 font-serif"
                 onClick={() => setShowConfirmation(false)}
               >
                 戻る（修正する）
               </button>
               <button
                 type="button"
-                className="bg-blue-600 text-white px-4 py-2 rounded flex-1"
+                className="bg-blue-600 text-white px-4 py-2 rounded flex-1 font-serif"
                 onClick={handleSubmit}
               >
                 この内容で予約する

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -60,7 +60,7 @@ export default function EventsPage() {
   }, []);
 
   return (
-    <main className="p-6 max-w-5xl mx-auto">
+    <main className="p-6 max-w-5xl mx-auto font-serif">
       <LinkBackToHome />
       <h1 className="text-2xl font-bold text-center mb-6">お茶会のご案内</h1>
       <div className="space-y-8">
@@ -88,7 +88,7 @@ export default function EventsPage() {
               </p>
               <p className="mb-4">{event.description}</p>
               <Link href={`/events/${event.id}`}>
-                <button className="w-32 mx-auto block bg-yellow-500 hover:bg-yellow-600 text-white py-2 rounded shadow transition-colors">
+                <button className="w-32 mx-auto block bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 rounded shadow transition-colors font-serif">
                   予約する
                 </button>
               </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import "./globals.css";
 const notoSerif = Noto_Serif_JP({
   variable: "--font-noto-serif",
   subsets: ["latin"],
-  weight: ["400", "700"],
+  weight: ["400", "500", "600", "700", "900"],
 });
 
 export const metadata: Metadata = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,10 +54,10 @@ export default function HomePage() {
         className="bg-cover bg-center min-h-[500px] sm:min-h-[600px] text-white flex flex-col justify-center items-center px-4"
         style={{ backgroundImage: `url('${topImageUrl}')` }}
       >
-        <h1 className="text-5xl sm:text-6xl font-extrabold mb-4 drop-shadow-md">
+        <h1 className="text-5xl sm:text-6xl font-bold mb-4 drop-shadow-md font-serif">
           石州流野村派
         </h1>
-        <p className="text-xl sm:text-2xl drop-shadow">茶会行事 予約サイト</p>
+        <p className="text-xl sm:text-2xl drop-shadow font-serif">茶会行事 予約サイト</p>
       </section>
 
       {/* ごあいさつセクション */}
@@ -93,17 +93,17 @@ export default function HomePage() {
       <section className="py-12 mb-8 max-w-5xl mx-auto px-4 text-center">
         <div className="flex flex-col sm:flex-row justify-center gap-4">
           <Link href="/events">
-            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow">
+            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow font-serif">
               お茶会のご案内
             </button>
           </Link>
           <Link href="/posts/past">
-            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow">
+            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow font-serif">
               過去の茶会紹介
             </button>
           </Link>
           <Link href="/posts/letters">
-            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow">
+            <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow font-serif">
               通信ページ
             </button>
           </Link>
@@ -112,11 +112,11 @@ export default function HomePage() {
 
       {/* 予約確認セクション */}
       <section className="py-8 bg-[#F5F0E6] border-t-4 border-[#C1A46F] text-center px-4 mt-8 max-w-5xl mx-auto">
-        <p className="mb-4 text-lg font-semibold text-[#8B5E3C]">
+        <p className="mb-4 text-lg font-semibold text-[#8B5E3C] font-serif">
           すでに予約済みの方はこちら
         </p>
         <Link href="/reservations/confirm">
-          <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow transition-colors">
+          <button className="bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 px-6 rounded shadow transition-colors font-serif">
             予約の確認・変更はこちら
           </button>
         </Link>

--- a/components/LinkBackToHome.tsx
+++ b/components/LinkBackToHome.tsx
@@ -4,7 +4,7 @@ export default function LinkBackToHome() {
   return (
     <Link
       href="/"
-      className="inline-flex items-center text-sm text-blue-600 hover:text-blue-800 mb-4 font-medium"
+      className="inline-flex items-center text-sm text-blue-600 hover:text-blue-800 mb-4 font-medium font-serif"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## 概要
- Noto Serif JPの利用ウェイトを拡張し、全ページでフォントを統一
- トップページおよび各ページ共通リンクのフォントをNoto Serifに統一
- お茶会一覧ページの「予約する」ボタンをブランドカラーに変更

## テスト
- `npm test` を実行（スクリプト未定義のため失敗）
- `npm run lint` を実行

------
https://chatgpt.com/codex/tasks/task_e_6891830a26048324aba5e54be31b8051