### PR TITLE
過去記事・通信ページのフォントを「ごあいさつ」と同じに統一

### DIFF
--- a/app/posts/letters/[id]/page.tsx
+++ b/app/posts/letters/[id]/page.tsx
@@ -23,12 +23,12 @@ export default function LetterDetailPage() {
     fetchPost();
   }, [id]);
 
-  if (!post) return <p className="p-6">読み込み中...</p>;
+  if (!post) return <p className="p-6 font-serif">読み込み中...</p>;
 
   const date = new Date(post.createdAt).toLocaleDateString("ja-JP");
 
   return (
-    <main className="p-6 max-w-3xl mx-auto">
+    <main className="p-6 max-w-3xl mx-auto font-serif">
       <LinkBackToHome />
       {post.imageUrl && (
         // eslint-disable-next-line @next/next/no-img-element
@@ -38,8 +38,10 @@ export default function LetterDetailPage() {
           className="w-full rounded mb-4"
         />
       )}
-      <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
-      <div className="whitespace-pre-wrap text-gray-700 mb-4">{post.body}</div>
+      <h1 className="text-3xl font-bold mb-4 font-serif">{post.title}</h1>
+      <div className="whitespace-pre-wrap text-gray-700 mb-4">
+        {post.body}
+      </div>
       <p className="text-right text-sm text-gray-500">{date}</p>
     </main>
   );

--- a/app/posts/letters/page.tsx
+++ b/app/posts/letters/page.tsx
@@ -21,9 +21,11 @@ export default function LettersPage() {
   }, []);
 
   return (
-    <main className="p-6 max-w-5xl mx-auto">
+    <main className="p-6 max-w-5xl mx-auto font-serif">
       <LinkBackToHome />
-      <h1 className="text-2xl font-bold mb-6 text-center">通信ページ</h1>
+      <h1 className="text-2xl font-bold mb-6 text-center font-serif">
+        通信ページ
+      </h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => (
           <BlogCard key={post.id} post={post} href={`/posts/letters/${post.id}`} />

--- a/app/posts/past/[id]/page.tsx
+++ b/app/posts/past/[id]/page.tsx
@@ -23,12 +23,12 @@ export default function PastPostDetailPage() {
     fetchPost();
   }, [id]);
 
-  if (!post) return <p className="p-6">読み込み中...</p>;
+  if (!post) return <p className="p-6 font-serif">読み込み中...</p>;
 
   const date = new Date(post.createdAt).toLocaleDateString("ja-JP");
 
   return (
-    <main className="p-6 max-w-3xl mx-auto">
+    <main className="p-6 max-w-3xl mx-auto font-serif">
       <LinkBackToHome />
       {post.imageUrl && (
         // eslint-disable-next-line @next/next/no-img-element
@@ -38,8 +38,10 @@ export default function PastPostDetailPage() {
           className="w-full rounded mb-4"
         />
       )}
-      <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
-      <div className="whitespace-pre-wrap text-gray-700 mb-4">{post.body}</div>
+      <h1 className="text-3xl font-bold mb-4 font-serif">{post.title}</h1>
+      <div className="whitespace-pre-wrap text-gray-700 mb-4">
+        {post.body}
+      </div>
       <p className="text-right text-sm text-gray-500">{date}</p>
     </main>
   );

--- a/app/posts/past/page.tsx
+++ b/app/posts/past/page.tsx
@@ -21,9 +21,11 @@ export default function PastPostsPage() {
   }, []);
 
   return (
-    <main className="p-6 max-w-5xl mx-auto">
+    <main className="p-6 max-w-5xl mx-auto font-serif">
       <LinkBackToHome />
-      <h1 className="text-2xl font-bold mb-6 text-center">過去の茶会紹介</h1>
+      <h1 className="text-2xl font-bold mb-6 text-center font-serif">
+        過去の茶会紹介
+      </h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => (
           <BlogCard key={post.id} post={post} href={`/posts/past/${post.id}`} />

--- a/components/BlogCard.tsx
+++ b/components/BlogCard.tsx
@@ -11,7 +11,10 @@ export default function BlogCard({ post, href }: Props) {
   const preview =
     post.body.length > 60 ? post.body.slice(0, 60) + "..." : post.body;
   return (
-    <Link href={href} className="block rounded-lg overflow-hidden shadow-lg bg-white hover:shadow-xl transition-shadow">
+    <Link
+      href={href}
+      className="block rounded-lg overflow-hidden shadow-lg bg-white hover:shadow-xl transition-shadow"
+    >
       {post.imageUrl && (
         <div className="h-48 w-full overflow-hidden">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -22,7 +25,7 @@ export default function BlogCard({ post, href }: Props) {
           />
         </div>
       )}
-      <div className="p-6">
+      <div className="p-6 font-serif">
         <h2 className="text-2xl font-bold mb-2">{post.title}</h2>
         <p className="whitespace-pre-wrap text-gray-700">{preview}</p>
         <p className="text-right text-sm text-gray-500 mt-4">{date}</p>


### PR DESCRIPTION
## Summary
- 過去の茶会紹介・通信ページおよび各記事ページで `font-serif` を追加し、「ごあいさつ」と同じ書体に統一
- BlogCard コンポーネントでも本文のフォントを `font-serif` に統一

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689188b08d6883248194a4f055e87976