### PR TITLE
feat: add image upload API and test page

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: "ファイルが選択されていません" }, { status: 400 });
+    }
+
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+
+    const uploadDir = path.join(process.cwd(), "public", "uploads");
+    await mkdir(uploadDir, { recursive: true });
+
+    const uniqueName = `${Date.now()}-${file.name}`;
+    const filePath = path.join(uploadDir, uniqueName);
+    await writeFile(filePath, buffer);
+
+    const url = `/uploads/${uniqueName}`;
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "アップロードに失敗しました" }, { status: 500 });
+  }
+}

--- a/app/upload-test/page.tsx
+++ b/app/upload-test/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+
+export default function UploadTestPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [imageUrl, setImageUrl] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [uploading, setUploading] = useState<boolean>(false);
+
+  const handleUpload = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!file) return;
+    setUploading(true);
+    setError('');
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+      if (res.ok && data.url) {
+        setImageUrl(data.url);
+      } else {
+        setError(data.error || 'アップロードに失敗しました');
+      }
+    } catch (err) {
+      console.error(err);
+      setError('アップロードに失敗しました');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <form onSubmit={handleUpload} className="space-y-4">
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          className="block"
+        />
+        <button
+          type="submit"
+          disabled={!file || uploading}
+          className={`px-4 py-2 text-white rounded ${
+            !file || uploading
+              ? 'bg-gray-400 cursor-not-allowed'
+              : 'bg-blue-500 hover:bg-blue-600'
+          }`}
+        >
+          {uploading ? 'アップロード中...' : 'アップロード'}
+        </button>
+      </form>
+      {error && <p className="text-red-500">{error}</p>}
+      {imageUrl && (
+        <div>
+          <p>アップロードされた画像:</p>
+          <img src={imageUrl} alt="uploaded" className="mt-2 max-w-xs" />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoint to save uploaded images under `/public/uploads`
- add test page to upload and display images
- make upload button submit via form and show errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689184db74f883249f6a2603b81ee2f4