### PR TITLE
fix: upload API を Node.js ランタイムに設定

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 
+export const runtime = 'nodejs';
+
 export async function POST(req: Request) {
   try {
     const formData = await req.formData();


### PR DESCRIPTION
## Summary
- upload API のランタイムを Node.js に指定

## Testing
- `npm test` (missing script)
- `npm run lint`
- 開発サーバーで `/upload-test` と `/api/upload` を確認


------
https://chatgpt.com/codex/tasks/task_e_689193a36f9c832499f7a92fd3936ec0