### PR TITLE
fix: upload API を Node.js ランタイムに設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # production
 /build
 
+# uploaded files
+public/uploads
+
 # misc
 .DS_Store
 *.pem

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 
+export const runtime = 'nodejs';
+
+export const dynamic = 'force-dynamic';
+
 export async function POST(req: Request) {
   try {
     const formData = await req.formData();


### PR DESCRIPTION
## Summary
- upload API のランタイムを Node.js に指定
- uploads ディレクトリを Git 管理対象外に設定

## Testing
- `npm test` (missing script)
- `npm run lint`
- `npm run dev` & `curl -F file=@package.json http://localhost:3002/api/upload`

------
https://chatgpt.com/codex/tasks/task_e_689193a36f9c832499f7a92fd3936ec0