### PR TITLE
fix: upload images to Firebase Storage

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { writeFile, mkdir } from "fs/promises";
-import path from "path";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import { storage } from "@/lib/firebase";
 
 export const runtime = 'nodejs';
 
@@ -9,23 +9,23 @@ export const dynamic = 'force-dynamic';
 export async function POST(req: Request) {
   try {
     const formData = await req.formData();
-    const file = formData.get("file") as File | null;
-
-    if (!file) {
-      return NextResponse.json({ error: "ファイルが選択されていません" }, { status: 400 });
+    const file = formData.get("file");
+    if (!file || typeof file === "string") {
+      return NextResponse.json({
+        error: "ファイルが選択されていません",
+      }, { status: 400 });
     }
 
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
 
-    const uploadDir = path.join(process.cwd(), "public", "uploads");
-    await mkdir(uploadDir, { recursive: true });
-
     const uniqueName = `${Date.now()}-${file.name}`;
-    const filePath = path.join(uploadDir, uniqueName);
-    await writeFile(filePath, buffer);
+    const storageRef = ref(storage, `images/${uniqueName}`);
 
-    const url = `/uploads/${uniqueName}`;
+    const snapshot = await uploadBytes(storageRef, buffer, {
+      contentType: file.type,
+    });
+    const url = await getDownloadURL(snapshot.ref);
     return NextResponse.json({ url });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- save uploaded images to Firebase Storage instead of local disk
- validate file presence and return download URL

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895aa5eb8cc8324bda5895870a8e0e3