### PR TITLE
fix: load ReactQuill synchronously and apply findDOMNode shim

### DIFF
--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef, forwardRef } from "react";
-import dynamic from "next/dynamic";
-import type ReactQuillType from "react-quill";
-import type { ReactQuillProps } from "react-quill";
+import "@/app/react-dom-finddomnode-polyfill";
+
+import { useState, useEffect, useRef } from "react";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
 import { db } from "@/lib/firebase";
 import {
   collection,
@@ -24,17 +25,6 @@ interface Props {
   storagePath: string;
 }
 
-const ReactQuill = dynamic(async () => {
-  const { default: RQ } = await import("react-quill");
-  const ReactQuillWithRef = forwardRef<ReactQuillType, ReactQuillProps>((props, ref) => (
-    <RQ ref={ref} {...props} />
-  ));
-  ReactQuillWithRef.displayName = "ReactQuill";
-  return ReactQuillWithRef;
-}, {
-  ssr: false,
-});
-
 export default function AdminBlogEditor({ collectionName, heading, storagePath }: Props) {
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [title, setTitle] = useState("");
@@ -45,7 +35,7 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
   const [editingId, setEditingId] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc");
   const inputRef = useRef<HTMLInputElement>(null);
-  const quillRef = useRef<ReactQuillType | null>(null);
+  const quillRef = useRef<ReactQuill | null>(null);
 
   const modules = {
     toolbar: {


### PR DESCRIPTION
## Summary
- load ReactQuill synchronously and drop dynamic wrapper
- add robust findDOMNode polyfill for namespace & default exports

## Testing
- `npm ci`
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac558e3b10832492e14b0d8bf71beb