### PR TITLE
fix admin blog editor hydration

### DIFF
--- a/app/admin2/letters/page.tsx
+++ b/app/admin2/letters/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// SSG を止めてサーバー側での静的プリレンダを回避
+export const dynamic = "force-dynamic";
+
 import AdminBlogEditor from "@/components/AdminBlogEditor";
 import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
 

--- a/app/admin2/past-posts/page.tsx
+++ b/app/admin2/past-posts/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// 念のためこちらも SSG を止める（同じ Editor を使うため）
+export const dynamic = "force-dynamic";
+
 import AdminBlogEditor from "@/components/AdminBlogEditor";
 import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
 

--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+// ポリフィルは最速で適用
 import "@/app/react-dom-finddomnode-polyfill";
-
 import { useState, useEffect, useRef } from "react";
-import ReactQuill from "react-quill";
+import dynamic from "next/dynamic";
+import type ReactQuillType from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import { db } from "@/lib/firebase";
 import {
@@ -35,7 +36,11 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
   const [editingId, setEditingId] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc");
   const inputRef = useRef<HTMLInputElement>(null);
-  const quillRef = useRef<ReactQuill | null>(null);
+  const quillRef = useRef<ReactQuillType | null>(null);
+
+// ReactQuill をクライアントだけで読み込む（SSG/SSR では import されない）
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ReactQuill = dynamic(() => import("react-quill"), { ssr: false }) as any;
 
   const modules = {
     toolbar: {


### PR DESCRIPTION
## Summary
- use dynamic import for ReactQuill on admin editor
- disable static generation for admin letter pages

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac587b4d58832490c8a22a0c616b7c