### PR TITLE
Fix image resize registration in ReactQuill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "date-fns": "^4.1.0",
         "firebase": "^11.6.1",
         "next": "15.3.1",
+        "quill": "^1.3.7",
         "quill-image-resize-module": "^3.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "date-fns": "^4.1.0",
     "firebase": "^11.6.1",
     "next": "15.3.1",
+    "quill": "^1.3.7",
     "quill-image-resize-module": "^3.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary
- add `quill` as an explicit dependency
- ensure image resize module is registered on the Quill instance used by ReactQuill, with render guard

## Testing
- `npm ci`
- `npm dedupe`
- `npm run build` *(fails: Missing API key for Resend)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c37fa2c8324a694b30fee06166e