### PR TITLE
refactor: replace color vars with tailwind tokens

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -92,17 +92,17 @@ export default function HomePage() {
       <section className="py-12 mb-8 max-w-5xl mx-auto px-4 text-center">
         <div className="flex flex-col sm:flex-row justify-center gap-4">
           <Link href="/events">
-            <button className="bg-[--color-primary] hover:bg-[--color-primary-hover] text-white py-2 px-6 rounded shadow font-serif">
+            <button className="bg-primary hover:bg-primary-hover text-white py-2 px-6 rounded shadow font-serif">
               お茶会のご案内
             </button>
           </Link>
           <Link href="/posts/past">
-            <button className="bg-[--color-primary] hover:bg-[--color-primary-hover] text-white py-2 px-6 rounded shadow font-serif">
+            <button className="bg-primary hover:bg-primary-hover text-white py-2 px-6 rounded shadow font-serif">
               過去の茶会紹介
             </button>
           </Link>
           <Link href="/posts/letters">
-            <button className="bg-[--color-primary] hover:bg-[--color-primary-hover] text-white py-2 px-6 rounded shadow font-serif">
+            <button className="bg-primary hover:bg-primary-hover text-white py-2 px-6 rounded shadow font-serif">
               通信ページ
             </button>
           </Link>
@@ -110,12 +110,12 @@ export default function HomePage() {
       </section>
 
       {/* 予約確認セクション */}
-      <section className="py-8 bg-[--color-primary] border-t-4 border-[--color-border] text-center px-4 mt-8 max-w-5xl mx-auto text-white">
+      <section className="py-8 bg-primary border-t-4 border-border text-center px-4 mt-8 max-w-5xl mx-auto text-white">
         <p className="mb-4 text-lg font-semibold font-serif">
           すでに予約済みの方はこちら
         </p>
         <Link href="/reservations/confirm">
-          <button className="bg-[--color-primary-hover] hover:bg-[--color-border] text-white py-2 px-6 rounded shadow transition-colors font-serif border border-[--color-border]">
+          <button className="bg-primary-hover hover:bg-border text-white py-2 px-6 rounded shadow transition-colors font-serif border border-border">
             予約の確認・変更はこちら
           </button>
         </Link>

--- a/components/AdminGreetingSettings.tsx
+++ b/components/AdminGreetingSettings.tsx
@@ -94,7 +94,7 @@ export default function AdminGreetingSettings() {
       <ReactQuill ref={quillRef} value={html} onChange={setHtml} modules={modules} formats={formats} />
       <button
         onClick={handleSave}
-        className="mt-4 bg-[--color-primary] hover:bg-[--color-primary-hover] text-white px-4 py-2 rounded"
+        className="mt-4 bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded"
       >
         保存
       </button>

--- a/components/AdminTopImageSettings.tsx
+++ b/components/AdminTopImageSettings.tsx
@@ -120,7 +120,7 @@ export default function AdminTopImageSettings() {
       <button
         onClick={handleSave}
         disabled={uploading}
-        className="bg-[--color-primary] hover:bg-[--color-primary-hover] text-white px-4 py-2 rounded disabled:opacity-50"
+        className="bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded disabled:opacity-50"
       >
         {uploading ? `保存中...${progress.toFixed(0)}%` : "保存"}
       </button>


### PR DESCRIPTION
## Summary
- replace bracket color classes with tailwind tokens for consistent theme

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b14bfb39cc83248bf8aef5ec627c0c