### PR TITLE
過去の茶会紹介：画像アップロード不具合の修正（contentType整合・URLリトライ）

### DIFF
--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -43,7 +43,7 @@ function validateImage(file: File): boolean {
     return false;
   }
   const ext = file.name.split(".").pop()?.toLowerCase();
-  if (!ext || !["jpg", "jpeg", "png", "gif", "webp", "svg"].includes(ext)) {
+  if (!ext || !["jpg", "jpeg", "png", "gif", "webp", "svg", "svgz"].includes(ext)) {
     alert("対応していない画像形式です");
     return false;
   }
@@ -213,6 +213,8 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
               const html = buildImagesHtml(urls);
               editor.clipboard.dangerouslyPasteHTML(range.index, html);
               editor.setSelection(range.index + 1, 0, "user");
+            } else if (urls.length === 0) {
+              showToastRef.current("画像のアップロードに失敗しました");
             }
             if (toolbarBtn) toolbarBtn.disabled = false;
             setUploading(false);

--- a/lib/validateImage.ts
+++ b/lib/validateImage.ts
@@ -1,9 +1,11 @@
 export const IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
+const ALLOWED_EXTS = ["jpg", "jpeg", "png", "gif", "webp", "svg", "svgz"];
+
 export function validateImage(file: File): boolean {
   const ext = file.name.split(".").pop()?.toLowerCase();
-  if (!ext || !["jpg", "jpeg", "png"].includes(ext)) {
-    alert("jpg/jpeg/png 形式の画像のみアップロードできます");
+  if (!ext || !ALLOWED_EXTS.includes(ext)) {
+    alert("jpg/jpeg/png/gif/webp/svg/svgz 形式の画像のみアップロードできます");
     return false;
   }
   if (file.size > IMAGE_MAX_SIZE) {


### PR DESCRIPTION
## Summary
- infer image content type or map from extension and retry getDownloadURL with exponential backoff
- allow gif/webp/svg/svgz images and validate size before upload
- insert only successfully uploaded images in bulk and notify when none succeed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b163caa16483249f25e733e46ee3e2