### PR TITLE
fix: improve admin editor image handling

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -60,6 +60,7 @@ export interface BlogPost {
   id: string;
   title: string;
   body: string; // HTML 文字列
+  bodyDelta?: unknown; // Quill Delta JSON
   createdAt: string;
   imageUrl?: string;
   images?: string[];


### PR DESCRIPTION
## Summary
- keep image sizes and multi-image layout in admin blog editor
- store post content as Delta with HTML fallback and log Firestore errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b16994bc508324aa9e00b6cd79fe89