### PR TITLE
Fix data/blob image handling in AdminBlogEditor

### DIFF
--- a/lib/storageImages.ts
+++ b/lib/storageImages.ts
@@ -75,7 +75,7 @@ export async function uploadImageToStorage(
     blob = input;
     name = input.name;
   } else {
-    blob = input;
+    blob = input as Blob;
   }
   if (blob.size > IMAGE_MAX_SIZE) throw new Error("File too large");
   const ext = getExt(name, blob.type);


### PR DESCRIPTION
## Summary
- refactor AdminBlogEditor to upload data/blob images asynchronously
- handle data/blob URL normalization outside clipboard matcher
- fix type issue in storageImages utility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)


------
https://chatgpt.com/codex/tasks/task_e_68b16da55b0483249a7d852ed82bbba0