### PR TITLE
Firestore 保存用に bodyDelta を完全シリアライズ

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -60,7 +60,7 @@ export interface BlogPost {
   id: string;
   title: string;
   body: string; // HTML 文字列
-  bodyDelta?: unknown; // Quill Delta JSON
+  bodyDelta?: { ops: unknown[] } | null; // Quill Delta JSON
   createdAt: string;
   imageUrl?: string;
   images?: string[];


### PR DESCRIPTION
## Summary
- Firestore へ保存する前に Quill Delta を JSON 化し、未シリアライズのエラーを回避
- bodyDelta がプレーン JSON か検証する `isPlainJSON` を追加
- BlogPost 型に bodyDelta の ops 配列を明示

## Testing
- `npm test` (Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1700312c0832495d89e479c2c6e92