### PR TITLE
イベント編集にごあいさつと複数会場入力を追加

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -17,10 +17,12 @@ export default function EventsPage() {
       const data = snapshot.docs
         .map((doc) => {
           const d = doc.data();
+          const venues = d.venues || (d.venue ? [d.venue] : []);
           return {
             id: doc.id,
             title: d.title,
-            venue: d.venue,
+            venue: venues[0] || "",
+            venues,
             rawDate: d.date?.toDate() as Date,
             cost: d.cost,
             description: d.description,
@@ -41,6 +43,7 @@ export default function EventsPage() {
             id: ev.id,
             title: ev.title,
             venue: ev.venue,
+            venues: ev.venues,
             date: ev.rawDate.toLocaleDateString("ja-JP", {
               year: "numeric",
               month: "2-digit",

--- a/lib/text.ts
+++ b/lib/text.ts
@@ -1,0 +1,8 @@
+export function linkifyAndLineBreak(text: string): string {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  const withLinks = escaped.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+  return withLinks.replace(/\n/g, '<br>');
+}

--- a/types.ts
+++ b/types.ts
@@ -9,7 +9,12 @@ import type { Timestamp } from "firebase/firestore";
 export interface Event {
   id: string;
   title: string;
-  venue: string;
+  /** 単一会場（レガシー） */
+  venue?: string;
+  /** 複数会場 */
+  venues?: string[] | null;
+  /** ごあいさつの Quill Delta */
+  greetingDelta?: { ops: unknown[] } | null;
   date: Timestamp;
   description?: string;
   cost?: number;
@@ -21,6 +26,7 @@ export interface EventSummary {
   id: string;
   title: string;
   venue: string;
+  venues?: string[] | null;
   date: string;
   cost?: number;
   description?: string;


### PR DESCRIPTION
## 概要
- イベントにごあいさつ（Quill Delta）と複数会場情報を追加
- 会場テキストを改行とURLリンクに対応
- 公開ページでの表示ロジックと型定義を更新

## テスト
- `npm test`（スクリプト未定義）
- `npm run lint`
- `npm run build`（APIキー不足により失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b25fbda7e483248fc164e51544b771