### PR TITLE
fix: use Delta instances for greeting editor

### DIFF
--- a/components/QuillClientEditor.tsx
+++ b/components/QuillClientEditor.tsx
@@ -34,6 +34,9 @@ const QuillClientEditor = forwardRef<QuillClientHandle, Props>(function QuillCli
     useEffect(() => {
       let quill: Quill | null = null;
       let mounted = true;
+      const handleChange = (delta: Delta, _old: Delta, source: string) => {
+        onChange?.(quill!.root.innerHTML, delta, source, quill!);
+      };
       (async () => {
         const QuillMod = await import("quill");
         const QuillCtor = QuillMod.default as unknown as typeof Quill;
@@ -50,15 +53,13 @@ const QuillClientEditor = forwardRef<QuillClientHandle, Props>(function QuillCli
             quill.setContents(value as Delta);
           }
         }
-        quill.on("text-change", (delta, _old, source) => {
-          onChange?.(quill!.root.innerHTML, delta, source, quill!);
-        });
+        quill.on("text-change", handleChange);
         if (mounted) editorRef.current = quill;
       })();
       return () => {
         mounted = false;
         if (quill) {
-          quill.off("text-change");
+          quill.off("text-change", handleChange);
           editorRef.current = null;
           quill = null;
         }
@@ -70,7 +71,7 @@ const QuillClientEditor = forwardRef<QuillClientHandle, Props>(function QuillCli
       const quill = editorRef.current;
       if (!quill) return;
       if (!value) {
-        quill.setContents([]);
+        quill.setContents([] as unknown as Delta);
         return;
       }
       if (typeof value === "string") {

--- a/types/quill-delta.d.ts
+++ b/types/quill-delta.d.ts
@@ -1,0 +1,6 @@
+declare module 'quill-delta' {
+  export default class Delta {
+    ops: unknown[];
+    constructor(delta?: unknown);
+  }
+}


### PR DESCRIPTION
## Summary
- use Delta class for Quill editor values in event editor
- declare quill-delta module types
- clean up QuillClientEditor event handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Missing API key for Resend)*

------
https://chatgpt.com/codex/tasks/task_e_68b265a30f84832498cacbfc6c989310