### PR TITLE
fix: Delta ops の型アサーション追加

### DIFF
--- a/types/quill-core.d.ts
+++ b/types/quill-core.d.ts
@@ -1,0 +1,9 @@
+declare module "quill/core" {
+  export interface DeltaOperation {
+    insert?: unknown;
+    delete?: number;
+    retain?: number;
+    attributes?: Record<string, unknown>;
+    [key: string]: unknown;
+  }
+}


### PR DESCRIPTION
## Summary
- Quill v2 の `delta.ops` が `unknown[]` になる問題を回避するため、`DeltaOperation` 型を明示的に利用
- 投稿保存時も `DeltaOperation[]` として `ops` を扱うよう調整
- `quill/core` の型定義を追加

## Testing
- `npm run lint`
- `RESEND_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2679cf5848324a56d952c0ac917e8