### PR TITLE
fix toolbar handler type

### DIFF
--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -342,8 +342,8 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
   useEffect(() => {
     const editor = quillRef.current?.getEditor();
     if (!editor) return;
-    const toolbar = editor.getModule("toolbar");
-    if (!toolbar) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const toolbar = editor.getModule("toolbar") as any;
     const onImageClick = () => {
       if (uploadingRef.current) return;
       const input = document.createElement("input");
@@ -397,7 +397,9 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
       };
       input.click();
     };
-    toolbar.addHandler("image", onImageClick);
+    if (toolbar && typeof toolbar.addHandler === "function") {
+      toolbar.addHandler("image", onImageClick);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isQuillReady]);
 


### PR DESCRIPTION
## Summary
- fix Quill toolbar handler type error in AdminBlogEditor

## Testing
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2696f2aa88324838b9ab8ed6fbba1