### PR TITLE
feat: add event cover image management

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -213,9 +213,13 @@ export default function EventDetailPage() {
 
   return (
     <main className="p-6 max-w-xl mx-auto font-serif">
-      {event.imageUrl && (
+      {event.coverImageUrl && (
         <div className="mb-4">
-          <img src={event.imageUrl} alt={event.title} className="w-full rounded" />
+          <img
+            src={event.coverImageUrl}
+            alt={event.coverImageAlt || ""}
+            className="w-full rounded"
+          />
         </div>
       )}
       <h1 className="text-2xl font-bold mb-4">{event.title}</h1>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { db } from "@/lib/firebase";
@@ -34,7 +33,8 @@ export default function EventsPage() {
               (sum: number, seat) => sum + (seat.capacity || 0),
               0
             ),
-            imageUrl: d.imageUrl || "/event1.jpg",
+            coverImageUrl: d.coverImageUrl || "",
+            coverImageAlt: d.coverImageAlt || "",
           };
         })
         .sort((a, b) => a.rawDate.getTime() - b.rawDate.getTime())
@@ -54,7 +54,8 @@ export default function EventsPage() {
             description: ev.description,
             participants: ev.participants,
             capacity: ev.capacity,
-            imageUrl: ev.imageUrl,
+            coverImageUrl: ev.coverImageUrl,
+            coverImageAlt: ev.coverImageAlt,
           } as EventSummary;
         });
       setEvents(data);
@@ -97,15 +98,15 @@ export default function EventsPage() {
               </Link>
             </div>
             <div className="w-full md:w-1/3">
-              <div className="relative w-full h-48 md:h-64 rounded overflow-hidden">
-                <Image
-                  src={event.imageUrl}
-                  alt={event.title}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 768px) 100vw, 33vw"
-                />
-              </div>
+              {event.coverImageUrl && (
+                <div className="relative w-full h-48 md:h-64 rounded overflow-hidden">
+                  <img
+                    src={event.coverImageUrl}
+                    alt={event.coverImageAlt || ""}
+                    className="object-cover w-full h-full"
+                  />
+                </div>
+              )}
             </div>
           </div>
         ))}

--- a/lib/validateImage.ts
+++ b/lib/validateImage.ts
@@ -1,11 +1,15 @@
 export const IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
-const ALLOWED_EXTS = ["jpg", "jpeg", "png", "gif", "webp", "svg", "svgz"];
+const ALLOWED_EXTS = ["jpg", "jpeg", "png", "gif", "webp"];
 
 export function validateImage(file: File): boolean {
   const ext = file.name.split(".").pop()?.toLowerCase();
   if (!ext || !ALLOWED_EXTS.includes(ext)) {
-    alert("jpg/jpeg/png/gif/webp/svg/svgz 形式の画像のみアップロードできます");
+    alert("jpg/jpeg/png/webp/gif 形式の画像のみアップロードできます");
+    return false;
+  }
+  if (!file.type.startsWith("image/")) {
+    alert("画像ファイルのみアップロードできます");
     return false;
   }
   if (file.size > IMAGE_MAX_SIZE) {

--- a/types.ts
+++ b/types.ts
@@ -19,7 +19,12 @@ export interface Event {
   description?: string;
   cost?: number;
   seats?: Seat[];
-  imageUrl?: string;
+  /** カード用の画像 URL */
+  coverImageUrl?: string;
+  /** Storage 内のパス */
+  coverImagePath?: string;
+  /** カード画像の代替テキスト */
+  coverImageAlt?: string;
 }
 
 export interface EventSummary {
@@ -32,7 +37,8 @@ export interface EventSummary {
   description?: string;
   participants?: number;
   capacity?: number;
-  imageUrl: string;
+  coverImageUrl?: string;
+  coverImageAlt?: string;
 }
 
 export interface Reservation {


### PR DESCRIPTION
## Summary
- add cover image fields for events and summaries
- allow admins to upload, delete, and annotate event card images with progress display
- show event cover images on public listings and detail pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68b26c9474a48324a1b0484d7705e558