### PR TITLE
feat: rename letters page to contact with form link

### DIFF
--- a/app/admin2/letters/page.tsx
+++ b/app/admin2/letters/page.tsx
@@ -11,7 +11,7 @@ export default function LettersAdminPage() {
       <LinkBackToAdmin2Top />
       <AdminBlogEditor
         collectionName="letters"
-        heading="通信ページ"
+        heading="お問い合わせ"
         storagePath={`${STORAGE_ROOT}/letters`}
       />
     </main>

--- a/app/admin2/page.tsx
+++ b/app/admin2/page.tsx
@@ -35,8 +35,8 @@ export default function AdminDashboard() {
           className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
           onClick={() => router.push("/admin2/letters")}
         >
-          <h2 className="text-xl font-semibold mb-2">✉ 通信ページ</h2>
-          <p>通信ページの記事を投稿します</p>
+          <h2 className="text-xl font-semibold mb-2">✉ お問い合わせ</h2>
+          <p>お問い合わせページを編集します</p>
         </div>
         <div
           className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -103,7 +103,7 @@ export default function HomePage() {
           </Link>
           <Link href="/posts/letters">
             <button className="bg-primary hover:bg-primary-hover text-white py-2 px-6 rounded shadow font-serif">
-              通信ページ
+              お問い合わせ
             </button>
           </Link>
         </div>

--- a/app/posts/letters/page.tsx
+++ b/app/posts/letters/page.tsx
@@ -1,35 +1,27 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { db } from "@/lib/firebase";
-import { collection, getDocs, query, orderBy } from "firebase/firestore";
-import type { BlogPost } from "@/types";
 import LinkBackToHome from "@/components/LinkBackToHome";
-import BlogCard from "@/components/BlogCard";
+import ContactFormButton from "@/components/ContactFormButton";
+import type { Metadata } from "next";
 
-export default function LettersPage() {
-  const [posts, setPosts] = useState<BlogPost[]>([]);
+export const metadata: Metadata = {
+  title: "お問い合わせ | 石州流野村派 茶会行事 予約サイト",
+  description: "お問い合わせページです",
+  openGraph: {
+    title: "お問い合わせ | 石州流野村派 茶会行事 予約サイト",
+    description: "お問い合わせページです",
+  },
+  twitter: {
+    title: "お問い合わせ | 石州流野村派 茶会行事 予約サイト",
+    description: "お問い合わせページです",
+  },
+};
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      const q = query(collection(db, "letters"), orderBy("createdAt", "desc"));
-      const snapshot = await getDocs(q);
-      const data = snapshot.docs.map((doc) => ({ id: doc.id, ...(doc.data() as Omit<BlogPost,"id">) }));
-      setPosts(data);
-    };
-    fetchPosts();
-  }, []);
-
+export default function ContactPage() {
   return (
     <main className="p-6 max-w-5xl mx-auto font-serif">
       <LinkBackToHome />
-      <h1 className="text-2xl font-bold mb-6 text-center font-serif">
-        通信ページ
-      </h1>
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {posts.map((post) => (
-          <BlogCard key={post.id} post={post} href={`/posts/letters/${post.id}`} />
-        ))}
+      <h1 className="text-2xl font-bold mb-6 text-center font-serif">お問い合わせ</h1>
+      <div className="text-center">
+        <ContactFormButton />
       </div>
     </main>
   );

--- a/components/ContactFormButton.tsx
+++ b/components/ContactFormButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ContactFormButton() {
+  const [disabled, setDisabled] = useState(false);
+
+  const handleClick = () => {
+    if (disabled) return;
+    setDisabled(true);
+    setTimeout(() => setDisabled(false), 300);
+  };
+
+  return (
+    <a
+      href="https://docs.google.com/forms/d/e/1FAIpQLSchijKElE7mr1nztp8jXd2ral113cZeDOxGC8Bll3k0KepQAQ/viewform?usp=header"
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={handleClick}
+      className={`inline-block bg-primary hover:bg-primary-hover text-white py-2 px-6 rounded shadow font-serif transition-colors ${disabled ? 'pointer-events-none opacity-50' : ''}`}
+    >
+      お問い合わせフォームを開く
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- rename letters page to "お問い合わせ" and add Google Form link
- update home and admin labels accordingly

## Testing
- `npm run lint`
- `npx --yes vercel build` *(fails: No Project Settings found)*
- `./node_modules/.bin/next build` *(fails: Missing Resend API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b2734102008324972b2bc92e020ea7