### PR TITLE
過去茶会紹介の画像をカルーセル表示に対応

### DIFF
--- a/app/posts/past/[id]/page.tsx
+++ b/app/posts/past/[id]/page.tsx
@@ -7,6 +7,7 @@ import { doc, getDoc } from "firebase/firestore";
 import type { BlogPost } from "@/types";
 import LinkBackToHome from "@/components/LinkBackToHome";
 import { deltaToHtml } from "@/lib/quillDelta";
+import RichHtml from "@/components/RichHtml";
 
 export default function PastPostDetailPage() {
   const { id } = useParams();
@@ -55,10 +56,9 @@ export default function PastPostDetailPage() {
         />
       )}
       <h1 className="text-3xl font-bold mb-4 font-serif">{post.title}</h1>
-      <div
-        className="text-gray-700 mb-4"
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      <div className="text-gray-700 mb-4">
+        <RichHtml html={html} />
+      </div>
       <p className="text-right text-sm text-gray-500">{date}</p>
     </main>
   );

--- a/components/AdminBlogEditor.tsx
+++ b/components/AdminBlogEditor.tsx
@@ -254,6 +254,7 @@ export default function AdminBlogEditor({ collectionName, heading, storagePath }
               value?.columns ?? (urls.length === 3 ? 3 : urls.length === 2 ? 2 : 2);
             node.setAttribute("data-urls", JSON.stringify(urls));
             node.setAttribute("data-columns", String(columns));
+            if (urls.length >= 2) node.setAttribute("data-gallery", "");
             if (urls.length === 2) {
               node.className = "my-4 grid gap-2 grid-cols-1 sm:grid-cols-2";
             } else if (urls.length === 3) {

--- a/components/GalleryCarousel.tsx
+++ b/components/GalleryCarousel.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import Autoplay from "embla-carousel-autoplay";
+
+interface ImageItem {
+  src: string;
+  alt?: string;
+}
+
+interface Props {
+  images: ImageItem[];
+  autoPlayMs?: number;
+}
+
+export default function GalleryCarousel({ images, autoPlayMs = 4000 }: Props) {
+  const [emblaRef, emblaApi] = useEmblaCarousel(
+    { loop: true },
+    [Autoplay({ delay: autoPlayMs, stopOnMouseEnter: true })]
+  );
+  const [selected, setSelected] = useState(0);
+  const [failed, setFailed] = useState(true);
+
+  useEffect(() => {
+    if (emblaApi) {
+      setFailed(false);
+      const onSelect = () => setSelected(emblaApi.selectedScrollSnap());
+      emblaApi.on("select", onSelect);
+      onSelect();
+    }
+  }, [emblaApi]);
+
+  const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
+  const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
+  const scrollTo = useCallback((i: number) => emblaApi?.scrollTo(i), [emblaApi]);
+
+  const buttonCls =
+    "absolute top-1/2 -translate-y-1/2 bg-black/50 text-white w-8 h-8 rounded-full flex items-center justify-center";
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") scrollPrev();
+      if (e.key === "ArrowRight") scrollNext();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [scrollPrev, scrollNext]);
+
+  if (images.length <= 1 || failed) {
+    return (
+      <div className="space-y-4 max-w-screen-md">
+        {images.map((img, i) => (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            key={i}
+            src={img.src}
+            alt={img.alt ?? ""}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-[240px] sm:h-[360px] object-cover rounded-2xl shadow ring-1 ring-black/5"
+            onError={e => {
+              e.currentTarget.src =
+                "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+              e.currentTarget.alt = "読み込めませんでした";
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative max-w-screen-md rounded-2xl shadow ring-1 ring-black/5 overflow-hidden"
+    >
+      <div className="overflow-hidden" ref={emblaRef}>
+        <div className="flex">
+          {images.map((img, i) => (
+            <div className="flex-[0_0_100%]" key={i}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={img.src}
+                alt={img.alt ?? ""}
+                loading="lazy"
+                decoding="async"
+                className="w-full h-[240px] sm:h-[360px] object-cover"
+                onError={e => {
+                  e.currentTarget.src =
+                    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+                  e.currentTarget.alt = "読み込めませんでした";
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={scrollPrev}
+        className={`${buttonCls} left-2`}
+      >
+        ‹
+      </button>
+      <button
+        type="button"
+        onClick={scrollNext}
+        className={`${buttonCls} right-2`}
+      >
+        ›
+      </button>
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-2">
+        {images.map((_, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => scrollTo(i)}
+            className={`w-2 h-2 rounded-full bg-white ${
+              selected === i ? "opacity-100" : "opacity-40"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/RichHtml.tsx
+++ b/components/RichHtml.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import parse, { Element, domToReact, DOMNode } from "html-react-parser";
+import GalleryCarousel from "./GalleryCarousel";
+
+interface Props {
+  html: string;
+  autoPlayMs?: number;
+}
+
+export default function RichHtml({ html, autoPlayMs }: Props) {
+  return (
+    <>{
+      parse(html, {
+        replace: node => {
+          if (node instanceof Element && node.name === "div") {
+            const attrs = node.attribs || {};
+            const cls = attrs.class || "";
+            const isGallery =
+              "data-gallery" in attrs || cls.split(/\s+/).includes("image-group");
+            if (isGallery) {
+              const imgs = (node.children || []).filter(
+                c => c instanceof Element && c.name === "img"
+              ) as Element[];
+              const images = imgs.map(img => ({
+                src: img.attribs.src,
+                alt: img.attribs.alt,
+              }));
+              if (images.length > 1) {
+                return <GalleryCarousel images={images} autoPlayMs={autoPlayMs} />;
+              }
+              return <>{domToReact(node.children as DOMNode[])}</>;
+            }
+          }
+          return undefined;
+        },
+      })
+    }</>
+  );
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "date-fns": "^4.1.0",
+        "embla-carousel-autoplay": "^8.6.0",
+        "embla-carousel-react": "^8.6.0",
         "firebase": "^11.6.1",
+        "html-react-parser": "^5.2.6",
         "next": "15.3.1",
         "quill": "^2.0.0",
         "quill-blot-formatter": "^1.0.5",
@@ -3408,6 +3411,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -4569,6 +4609,68 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
+      "integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.6.tgz",
+      "integrity": "sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.1",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.17"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-to-text": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
@@ -4661,6 +4763,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6303,6 +6411,12 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6955,6 +7069,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.9"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "date-fns": "^4.1.0",
+    "embla-carousel-autoplay": "^8.6.0",
+    "embla-carousel-react": "^8.6.0",
     "firebase": "^11.6.1",
+    "html-react-parser": "^5.2.6",
     "next": "15.3.1",
     "quill": "^2.0.0",
     "quill-blot-formatter": "^1.0.5",


### PR DESCRIPTION
## 概要
- `embla-carousel-react` と `html-react-parser` を導入
- フォトギャラリー用 `GalleryCarousel` コンポーネントを追加
- 連続画像ブロックを検出してカルーセルに差し替える `RichHtml` を実装
- 過去記事ページで `RichHtml` を利用するよう変更
- 管理画面の複数画像ブロックに `data-gallery` 属性を付与

## テスト
- `npm test` (スクリプト未定義のため実行できず)
- `npm run lint`
- `npm run build` (Resend の API キー不足により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68b277f3feac83248e554f155df2a2b8