### PR TITLE
Log upload token and scope link styles

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -5,8 +5,9 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
-  const token = req.headers.get('x-admin-upload-token');
-  if (token !== process.env.ADMIN_UPLOAD_TOKEN) {
+  const headerToken = req.headers.get('x-admin-upload-token');
+  console.log('header=', headerToken, 'env=', process.env.ADMIN_UPLOAD_TOKEN);
+  if (headerToken?.trim() != process.env.ADMIN_UPLOAD_TOKEN?.trim()) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   try {

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -225,7 +225,7 @@ export default function EventDetailPage() {
       <h1 className="text-2xl font-bold mb-4">{event.title}</h1>
       {event.greetingDelta && (
         <div
-          className="mb-4"
+          className="greeting-content mb-4"
           dangerouslySetInnerHTML={{ __html: deltaToHtml(event.greetingDelta) }}
         />
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,12 +28,13 @@ body {
   font-family: var(--font-serif), serif;
 }
 
-a {
+
+.greeting-content a {
   color: #1a0dab;
   text-decoration: underline;
 }
 
-a:hover {
+.greeting-content a:hover {
   color: #c00;
 }
 

--- a/lib/uploadViaApi.ts
+++ b/lib/uploadViaApi.ts
@@ -12,6 +12,7 @@ export async function uploadViaApi(
   return await new Promise<UploadResponse>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', '/api/upload');
+    console.log('sending token', process.env.NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN);
     xhr.setRequestHeader(
       'x-admin-upload-token',
       process.env.NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN!


### PR DESCRIPTION
## Summary
- debug upload API by logging header and token values, trim tokens before comparison
- log token sent from client
- apply link styling only within greeting section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b58e869c508324a5731702a5dab8a9