### PR TITLE
Check admin upload token before sending

### DIFF
--- a/lib/uploadViaApi.ts
+++ b/lib/uploadViaApi.ts
@@ -12,11 +12,12 @@ export async function uploadViaApi(
   return await new Promise<UploadResponse>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', '/api/upload');
-    console.log('sending token', process.env.NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN);
-    xhr.setRequestHeader(
-      'x-admin-upload-token',
-      process.env.NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN!
-    );
+    const token = process.env.NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN;
+    if (!token) {
+      throw new Error('NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN is not defined');
+    }
+    console.log('sending token', token);
+    xhr.setRequestHeader('x-admin-upload-token', token);
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable && onProgress) {
         onProgress(Math.round((e.loaded / e.total) * 100));


### PR DESCRIPTION
## Summary
- throw an error if `NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN` is not defined
- send the token only after validating its presence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5917d861c8324b6d48ba80376340f