### PR TITLE
管理画面の画像アップロード認証とプレビュー改善

### DIFF
--- a/app/admin2/layout.tsx
+++ b/app/admin2/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import EnsureAdminCookie from "@/components/EnsureAdminCookie";
+
+export default function Admin2Layout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <EnsureAdminCookie />
+      {children}
+    </>
+  );
+}

--- a/app/api/admin/session/route.ts
+++ b/app/api/admin/session/route.ts
@@ -1,17 +1,32 @@
 import { NextResponse } from "next/server";
+import { headers as nextHeaders } from "next/headers";
 
 export async function POST() {
-  const token = process.env.ADMIN_UPLOAD_TOKEN?.trim();
-  if (!token) {
+  const envToken = process.env.ADMIN_UPLOAD_TOKEN?.trim();
+  if (!envToken) {
     return NextResponse.json(
       { error: "ADMIN_UPLOAD_TOKEN is not set" },
       { status: 500 }
     );
   }
-  const res = new NextResponse(null, { status: 204 });
+
+  const headerToken = (await nextHeaders())
+    .get("x-admin-upload-token")
+    ?.trim();
+  if (!headerToken) {
+    return NextResponse.json(
+      { error: "x-admin-upload-token header is required" },
+      { status: 400 }
+    );
+  }
+  if (headerToken !== envToken) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const res = NextResponse.json({ ok: true }, { status: 200 });
   res.cookies.set({
     name: "admin_upload_token",
-    value: token,
+    value: envToken,
     httpOnly: true,
     secure: true,
     sameSite: "lax",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,7 +77,7 @@ export default function HomePage() {
         )}
         {greetingHtml ? (
           <div
-            className="text-lg font-serif space-y-4"
+            className="text-lg font-serif space-y-4 [&_a]:text-blue-600 [&_a]:underline"
             dangerouslySetInnerHTML={{ __html: greetingHtml }}
           />
         ) : (

--- a/components/AdminTopImageSettings.tsx
+++ b/components/AdminTopImageSettings.tsx
@@ -11,7 +11,7 @@ export default function AdminTopImageSettings() {
   const [alt, setAlt] = useState("");
   const [storagePath, setStoragePath] = useState("");
   const [file, setFile] = useState<File | null>(null);
-  const [preview, setPreview] = useState("");
+  const [previewUrl, setPreviewUrl] = useState("");
   const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -36,7 +36,10 @@ export default function AdminTopImageSettings() {
   const handleFileChange = (f: File) => {
     if (!validateImage(f)) return;
     setFile(f);
-    setPreview(URL.createObjectURL(f));
+    setPreviewUrl((p) => {
+      if (p) URL.revokeObjectURL(p);
+      return URL.createObjectURL(f);
+    });
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,6 +52,12 @@ export default function AdminTopImageSettings() {
     const f = e.dataTransfer.files?.[0];
     if (f) handleFileChange(f);
   };
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
 
   const handleSave = async () => {
     setUploading(true);
@@ -76,7 +85,7 @@ export default function AdminTopImageSettings() {
       setImageUrl(downloadUrl);
       setStoragePath(path);
       setFile(null);
-      setPreview("");
+      setPreviewUrl("");
       alert("保存しました");
     } catch (err) {
       console.error(err);
@@ -89,9 +98,9 @@ export default function AdminTopImageSettings() {
   return (
     <div className="p-6 max-w-xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">トップページ画像設定</h1>
-      {(preview || imageUrl) && (
+      {(previewUrl || imageUrl) && (
         <img
-          src={preview || imageUrl}
+          src={previewUrl || imageUrl}
           alt="プレビュー"
           className="w-full mb-4 rounded"
         />

--- a/components/EnsureAdminCookie.tsx
+++ b/components/EnsureAdminCookie.tsx
@@ -12,7 +12,11 @@ export default function EnsureAdminCookie() {
     const has = document.cookie.includes("admin_upload_token=");
     if (has) return;
 
-    fetch("/api/admin/session", { method: "POST" }).catch(() => {});
+    const token = process.env.NEXT_PUBLIC_ADMIN_UPLOAD_TOKEN;
+    fetch("/api/admin/session", {
+      method: "POST",
+      headers: token ? { "x-admin-upload-token": token } : undefined,
+    }).catch(() => {});
   }, []);
 
   return null;


### PR DESCRIPTION
## Summary
- 管理画面で `/api/admin/session` を呼び出す際にヘッダーでトークンを送信し、正しい値のみ `admin_upload_token` を発行するようにしました
- 画像プレビュー用 URL を状態に分離し、オブジェクト URL を適切に破棄して永続 URL のみを保存するようにしました
- トップページ「ごあいさつ」欄のリンクだけ青色・下線になるようスタイルを追加しました

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b599701abc8324a11aada3e0eb28b8