### PR TITLE
fix: polyfill react-dom default export for react-quill

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,8 @@
 import type { NextConfig } from "next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   // ✅ outputは指定しない（デフォルトのまま）
@@ -11,12 +15,18 @@ const nextConfig: NextConfig = {
       { protocol: "http", hostname: "**" },
     ],
   },
-  webpack: (config: any) => {
+  webpack: (config: any, { isServer }: { isServer: boolean }) => {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
-      'quill$': require.resolve('quill'),
+      "quill$": require.resolve("quill"),
     };
+    if (!isServer) {
+      config.resolve.alias["react-dom$"] = path.resolve(
+        __dirname,
+        "polyfills/react-dom-default.ts"
+      );
+    }
     return config;
   },
 };

--- a/polyfills/react-dom-default.ts
+++ b/polyfills/react-dom-default.ts
@@ -1,0 +1,5 @@
+import * as ReactDOMNS from "react-dom";
+// Provide a default export mirroring the named exports
+export default ReactDOMNS;
+// Re-export named exports transparently
+export * from "react-dom";


### PR DESCRIPTION
## Summary
- polyfill `react-dom` default export so legacy libs like react-quill can call `findDOMNode`
- alias `react-dom` to the polyfill in client webpack build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `RESEND_API_KEY=re_test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5bef6a5a88324a8d2122fb0a03916