### PR TITLE
fix: QuillLite の再初期化を抑止しツールバー増殖を解消

### DIFF
--- a/components/QuillLite.tsx
+++ b/components/QuillLite.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import type QuillType from "quill";
-import type { QuillOptionsStatic } from "quill";
+// テーマCSSはグローバルに読み込まれているためここでは未インポート
 import { uploadImage } from "@/lib/uploadImage";
 
 type Props = {
@@ -14,7 +14,15 @@ type Props = {
 export default function QuillLite({ value, onChange, eventId }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const quillRef = useRef<QuillType | null>(null);
+  const onChangeRef = useRef(onChange);
+  const initialAppliedRef = useRef(false);
 
+  // onChange は ref 経由で最新を参照（effectを再走らせない）
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  // ツールバー定義（安定化のため useMemo。依存は空配列）
   const toolbar = useMemo(
     () => [
       [{ header: [1, 2, 3, false] }],
@@ -26,23 +34,23 @@ export default function QuillLite({ value, onChange, eventId }: Props) {
     []
   );
 
+  // 初期化は一度だけ。value/onChange を依存に入れない
   useEffect(() => {
-    let mounted = true;
-    (async () => {
-      type QuillConstructor = new (
-        element: HTMLElement,
-        options?: QuillOptionsStatic
-      ) => QuillType;
-      const Quill = (await import("quill")).default as unknown as QuillConstructor;
-      if (!mounted || !containerRef.current) return;
+    if (!containerRef.current) return;
+    if (quillRef.current) return; // 既に初期化済みなら何もしない
 
-      const editor = new Quill(containerRef.current, {
+    (async () => {
+      const Quill = (await import("quill")).default as unknown as typeof import("quill");
+      // 念のため空にしてから初期化（増殖防止）
+      containerRef.current!.innerHTML = "";
+
+      const editor = new Quill(containerRef.current!, {
         theme: "snow",
         modules: {
           toolbar: {
             container: toolbar,
             handlers: {
-              image: async function handleImage() {
+              image: async () => {
                 const input = document.createElement("input");
                 input.type = "file";
                 input.accept = "image/*";
@@ -71,26 +79,41 @@ export default function QuillLite({ value, onChange, eventId }: Props) {
 
       quillRef.current = editor;
 
-      if (value) {
+      // 初期値は一度だけ反映
+      if (value && !initialAppliedRef.current) {
         editor.clipboard.dangerouslyPasteHTML(value);
+        initialAppliedRef.current = true;
       }
 
+      // text-change は1回だけ登録。最新の onChange は ref から読む
       editor.on("text-change", () => {
         const html = editor.root.innerHTML;
-        onChange(html);
+        onChangeRef.current(html);
       });
     })();
+    // 依存は空配列（=1度だけ）。StrictMode 下でも quillRef ガードで多重初期化を抑止
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- ★ここを [] にするのが肝
 
-    return () => {
-      mounted = false;
-      quillRef.current = null;
-    };
-  }, [eventId, onChange, toolbar, value]);
+  // 外部から value が変わった時だけ（かつエディタが非フォーカス時）同期
+  useEffect(() => {
+    const editor = quillRef.current;
+    if (!editor) return;
 
-  return (
-    <div className="quill-lite">
-      <div ref={containerRef} />
-    </div>
-  );
+    // 初期適用がまだならここで一度だけ適用
+    if (value && !initialAppliedRef.current) {
+      editor.clipboard.dangerouslyPasteHTML(value);
+      initialAppliedRef.current = true;
+      return;
+    }
+
+    // エディタ未フォーカス時のみ同期（編集中の上書きを避ける）
+    const focused = editor.hasFocus ? editor.hasFocus() : document.activeElement === editor.root;
+    const current = editor.root.innerHTML;
+    if (!focused && value != null && value !== current) {
+      editor.root.innerHTML = value;
+    }
+  }, [value]);
+
+  return <div ref={containerRef} />;
 }
 


### PR DESCRIPTION
## Summary
- QuillLite を再初期化しない構成に変更し、キー入力時のツールバー増殖を防止
- 外部 value との同期はエディタ非フォーカス時のみ行うように調整

## Testing
- `npm test` (script missing)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5c84a138483249b2a6c89f6f4c7df