### PR TITLE
ごあいさつエディタの揃え対応とイベント画像の整理

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import Image from "next/image";
 import { db } from "@/lib/firebase";
 import {
   doc,
@@ -18,10 +17,7 @@ import { updateParticipantCount } from "@/lib/updateParticipantCount";
 import { updateSeatReservedCount } from "@/lib/updateSeatReservedCount";
 import type { Event, Seat } from "@/types";
 import { linkifyAndLineBreak } from "@/lib/text";
-import { isUnsafeImageSrc, stripBlobImages } from "@/utils/url";
-
-const firstImg = (html: string) =>
-  html.match(/<img[^>]+src="([^\"]+)"/i)?.[1] || null;
+import { stripBlobImages } from "@/utils/url";
 
 export default function EventDetailPage() {
   const { id } = useParams();
@@ -216,20 +212,6 @@ export default function EventDetailPage() {
 
   return (
     <main className="p-6 max-w-xl mx-auto font-serif">
-      {(() => {
-        const cover = firstImg(event.greeting || "");
-        return cover && !isUnsafeImageSrc(cover) ? (
-          <div className="mb-4">
-            <Image
-              src={cover}
-              alt=""
-              width={800}
-              height={600}
-              className="w-full h-auto rounded"
-            />
-          </div>
-        ) : null;
-      })()}
       <h1 className="text-2xl font-bold mb-4">{event.title}</h1>
       {event.greeting && (
         <div

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -2,15 +2,11 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import Image from "next/image";
 import { db } from "@/lib/firebase";
 import { collection, getDocs } from "firebase/firestore";
 import type { EventSummary, Seat } from "@/types";
 import LinkBackToHome from "@/components/LinkBackToHome";
-import { isUnsafeImageSrc } from "@/utils/url";
-
-const firstImg = (html: string) =>
-  html.match(/<img[^>]+src="([^\"]+)"/i)?.[1] || null;
+ 
 
 export default function EventsPage() {
   const [events, setEvents] = useState<EventSummary[]>([]);
@@ -22,7 +18,6 @@ export default function EventsPage() {
         .map((doc) => {
           const d = doc.data();
           const venues = d.venues || (d.venue ? [d.venue] : []);
-          const greeting = d.greeting || "";
           return {
             id: doc.id,
             title: d.title,
@@ -39,7 +34,6 @@ export default function EventsPage() {
               (sum: number, seat) => sum + (seat.capacity || 0),
               0
             ),
-            thumbnailUrl: firstImg(greeting),
           };
         })
         .sort((a, b) => a.rawDate.getTime() - b.rawDate.getTime())
@@ -59,7 +53,6 @@ export default function EventsPage() {
             description: ev.description,
             participants: ev.participants,
             capacity: ev.capacity,
-            thumbnailUrl: ev.thumbnailUrl,
           } as EventSummary;
         });
       setEvents(data);
@@ -75,45 +68,30 @@ export default function EventsPage() {
         {events.map((event) => (
           <div
             key={event.id}
-            className="flex flex-col md:flex-row items-center gap-6 p-6 border rounded-lg shadow-lg bg-white hover:shadow-xl transition-shadow"
+            className="p-6 border rounded-lg shadow-lg bg-white hover:shadow-xl transition-shadow"
           >
-            <div className="flex-1">
-              <h2 className="text-xl font-bold mb-2">{event.title}</h2>
-              <p className="mb-1 font-semibold">
-                会場: <span className="font-normal">{event.venue}</span>
-              </p>
-              <p className="mb-1 font-semibold">
-                日時: <span className="font-normal">{event.date}</span>
-              </p>
-              <p className="mb-1 font-semibold">
-                参加費用: <span className="font-normal">{event.cost}円</span>
-              </p>
-              <p className="mb-3 font-semibold">
-                参加人数:
-                <span className="font-normal">
-                  {event.participants}/{event.capacity}人
-                </span>
-              </p>
-              <p className="mb-4">{event.description}</p>
-              <Link href={`/events/${event.id}`}>
-                <button className="w-32 mx-auto block bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 rounded shadow transition-colors font-serif">
-                  予約する
-                </button>
-              </Link>
-            </div>
-            <div className="w-full md:w-1/3">
-              {event.thumbnailUrl &&
-                !isUnsafeImageSrc(event.thumbnailUrl) && (
-                  <div className="relative w-full h-48 md:h-64 rounded overflow-hidden">
-                    <Image
-                      src={event.thumbnailUrl}
-                      alt=""
-                      fill
-                      className="object-cover"
-                    />
-                  </div>
-                )}
-            </div>
+            <h2 className="text-xl font-bold mb-2">{event.title}</h2>
+            <p className="mb-1 font-semibold">
+              会場: <span className="font-normal">{event.venue}</span>
+            </p>
+            <p className="mb-1 font-semibold">
+              日時: <span className="font-normal">{event.date}</span>
+            </p>
+            <p className="mb-1 font-semibold">
+              参加費用: <span className="font-normal">{event.cost}円</span>
+            </p>
+            <p className="mb-3 font-semibold">
+              参加人数:
+              <span className="font-normal">
+                {event.participants}/{event.capacity}人
+              </span>
+            </p>
+            <p className="mb-4">{event.description}</p>
+            <Link href={`/events/${event.id}`}>
+              <button className="w-32 mx-auto block bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 rounded shadow transition-colors font-serif">
+                予約する
+              </button>
+            </Link>
           </div>
         ))}
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -42,3 +42,11 @@ body {
   max-width: 100%;
   height: auto;
 }
+
+/* Quill の揃えを強制反映（.prose 等の上書き対策） */
+.prose .ql-align-center { text-align: center !important; }
+.prose .ql-align-right  { text-align: right  !important; }
+.prose .ql-align-justify{ text-align: justify !important; }
+.greeting-content .ql-align-center { text-align: center !important; }
+.greeting-content .ql-align-right  { text-align: right  !important; }
+.greeting-content .ql-align-justify{ text-align: justify !important; }

--- a/components/QuillLite.tsx
+++ b/components/QuillLite.tsx
@@ -30,6 +30,7 @@ export default function QuillLite({ value, onChange, eventId }: Props) {
       [{ header: [1, 2, 3, false] }],
       ["bold", "italic", "underline"],
       [{ list: "ordered" }, { list: "bullet" }],
+      [{ align: [] }],
       ["link", "image"],
       ["clean"],
     ],
@@ -80,6 +81,18 @@ export default function QuillLite({ value, onChange, eventId }: Props) {
             },
           },
         },
+        // 揃えなどを反映させるため formats を明示
+        formats: [
+          "header",
+          "bold",
+          "italic",
+          "underline",
+          "list",
+          "bullet",
+          "link",
+          "image",
+          "align",
+        ],
       });
 
       quillRef.current = editor;

--- a/types.ts
+++ b/types.ts
@@ -31,8 +31,6 @@ export interface EventSummary {
   description?: string;
   participants?: number;
   capacity?: number;
-  /** greeting 内の先頭画像 URL */
-  thumbnailUrl?: string;
 }
 
 export interface Reservation {


### PR DESCRIPTION
## 概要
- QuillLiteエディタに揃えボタンを追加し、alignフォーマットに対応
- QuillのCSS優先度を上げて公開時に揃えが反映されるよう調整
- イベント詳細ページの冒頭画像・イベント一覧のカード画像を撤廃
- EventSummary型から不要になった`thumbnailUrl`を削除

## 動作確認
- `npm test`（スクリプト未定義）
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b63aef01a48324ab6b71bba7a30634