### PR TITLE
Keep leading spaces in HTML content

### DIFF
--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "firebase/firestore";
 import type { Seat } from "@/types";
 import QuillLite from "@/components/QuillLite";
+import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
 
 const hourOptions = Array.from({ length: 24 }, (_, i) =>
   String(i).padStart(2, "0")
@@ -163,7 +164,7 @@ export default function EditEventPage() {
     const baseData = {
       title: form.title,
       venues: venues.length ? venues : null,
-      greeting: form.greeting || "",
+      greeting: preserveLeadingSpaces(form.greeting) || "",
       cost: Number(form.cost),
       date: Timestamp.fromDate(new Date(form.date)),
       description: form.description,

--- a/app/admin2/greeting/page.tsx
+++ b/app/admin2/greeting/page.tsx
@@ -5,6 +5,7 @@ import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
 import RichTextEditor from "@/components/RichTextEditor";
 import { db } from "@/lib/firebase";
 import { doc, getDoc, setDoc } from "firebase/firestore";
+import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
 
 export default function GreetingPage() {
   const [html, setHtml] = useState("");
@@ -41,7 +42,11 @@ export default function GreetingPage() {
 
   const handleSave = async () => {
     try {
-      await setDoc(doc(db, "settings", "publicSite"), { greetingHtml: html }, { merge: true });
+      await setDoc(
+        doc(db, "settings", "publicSite"),
+        { greetingHtml: preserveLeadingSpaces(html) },
+        { merge: true }
+      );
       showToast("ごあいさつを保存しました！");
     } catch (err) {
       console.error(err);

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -18,6 +18,7 @@ import { updateSeatReservedCount } from "@/lib/updateSeatReservedCount";
 import type { Event, Seat } from "@/types";
 import { linkifyAndLineBreak } from "@/lib/text";
 import { stripBlobImages } from "@/utils/url";
+import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
 
 export default function EventDetailPage() {
   const { id } = useParams();
@@ -39,7 +40,12 @@ export default function EventDetailPage() {
       if (snapshot.exists()) {
         const data = snapshot.data();
         const venues = data.venues || (data.venue ? [data.venue] : []);
-        setEvent({ id: snapshot.id, ...data, venues, greeting: data.greeting || "" } as Event);
+        setEvent({
+          id: snapshot.id,
+          ...data,
+          venues,
+          greeting: preserveLeadingSpaces(data.greeting || ""),
+        } as Event);
       }
     };
     fetchEvent();
@@ -215,7 +221,7 @@ export default function EventDetailPage() {
       <h1 className="text-2xl font-bold mb-4">{event.title}</h1>
       {event.greeting && (
         <div
-          className="greeting-content mb-4"
+          className="greeting-content mb-4 greeting-html"
           dangerouslySetInnerHTML={{ __html: stripBlobImages(event.greeting) }}
         />
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,3 +50,9 @@ body {
 .greeting-content .ql-align-center { text-align: center !important; }
 .greeting-content .ql-align-right  { text-align: right  !important; }
 .greeting-content .ql-align-justify{ text-align: justify !important; }
+
+/* 文頭・連続スペースと改行を保持して折り返す */
+.greeting-html,
+.rich-html {
+  white-space: pre-wrap;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { db } from "@/lib/firebase";
 import { doc, getDoc } from "firebase/firestore";
 import { INK_BUTTON } from "@/components/ui/buttonStyles";
 import { isUnsafeImageSrc, stripBlobImages } from "@/utils/url";
+import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
 
 export default function HomePage() {
   const [topImageUrl, setTopImageUrl] = useState("/hero-matcha.png");
@@ -32,7 +33,9 @@ export default function HomePage() {
         if (data.heroImageUrl) setTopImageUrl(data.heroImageUrl);
         if (data.heroImageAlt) setHeroImageAlt(data.heroImageAlt);
         if (data.greetingHtml) {
-          setGreetingHtml(data.greetingHtml as string);
+          setGreetingHtml(
+            preserveLeadingSpaces(data.greetingHtml as string)
+          );
         } else if (data.paragraphs) {
           setParagraphs(data.paragraphs as string[]);
         } else if (data.greetingLines) {
@@ -84,7 +87,7 @@ export default function HomePage() {
         )}
         {greetingHtml ? (
           <div
-            className="text-lg font-serif space-y-4 [&_a]:text-blue-600 [&_a]:underline"
+            className="text-lg font-serif space-y-4 [&_a]:text-blue-600 [&_a]:underline greeting-html"
             dangerouslySetInnerHTML={{ __html: stripBlobImages(greetingHtml) }}
           />
         ) : (

--- a/app/posts/past/[id]/page.tsx
+++ b/app/posts/past/[id]/page.tsx
@@ -10,6 +10,7 @@ import LinkBackToHome from "@/components/LinkBackToHome";
 import { deltaToHtml } from "@/lib/quillDelta";
 import RichHtml from "@/components/RichHtml";
 import { isUnsafeImageSrc } from "@/utils/url";
+import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
 
 export default function PastPostDetailPage() {
   const { id } = useParams();
@@ -31,14 +32,14 @@ export default function PastPostDetailPage() {
   useEffect(() => {
     if (!post) return;
     if (post.bodyDelta) {
-      setHtml(deltaToHtml(post.bodyDelta));
+      setHtml(preserveLeadingSpaces(deltaToHtml(post.bodyDelta)));
     } else if (post.bodyHtmlUrl) {
       fetch(post.bodyHtmlUrl)
         .then(res => res.text())
-        .then(setHtml)
-        .catch(() => setHtml(post.body || ""));
+        .then((t) => setHtml(preserveLeadingSpaces(t)))
+        .catch(() => setHtml(preserveLeadingSpaces(post.body || "")));
     } else {
-      setHtml(post.body || "");
+      setHtml(preserveLeadingSpaces(post.body || ""));
     }
   }, [post]);
 
@@ -59,7 +60,7 @@ export default function PastPostDetailPage() {
         />
       )}
       <h1 className="text-3xl font-bold mb-4 font-serif">{post.title}</h1>
-      <div className="text-gray-700 mb-4">
+      <div className="text-gray-700 mb-4 rich-html">
         <RichHtml html={html} />
       </div>
       <p className="text-right text-sm text-gray-500">{date}</p>

--- a/lib/preserveLeadingSpaces.ts
+++ b/lib/preserveLeadingSpaces.ts
@@ -1,0 +1,20 @@
+// lib/preserveLeadingSpaces.ts
+// ブロック要素直後や <br> 直後の連続スペースを &nbsp; に変換して保持する
+export function preserveLeadingSpaces(html: string): string {
+  if (!html) return html;
+
+  // ① <p|div|li|h1..h6>直後の先頭スペース群
+  html = html.replace(
+    /<(p|div|li|h[1-6])(\s[^>]*)?>(\s+)/g,
+    (_m, tag, attrs = "", spaces) =>
+      `<${tag}${attrs || ""}>` + spaces.replace(/ /g, "&nbsp;")
+  );
+
+  // ② <br>直後の行頭スペース群（複数行対応）
+  html = html.replace(
+    /(<br\s*\/?>(?:\s*\n)?)(\s+)/g,
+    (_m, br, spaces) => br + spaces.replace(/ /g, "&nbsp;")
+  );
+
+  return html;
+}


### PR DESCRIPTION
## Summary
- add `preserveLeadingSpaces` utility to convert leading spaces to `&nbsp;`
- apply space preservation when saving greetings, events and past posts
- ensure frontend wrappers display with `white-space: pre-wrap`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Missing API key for Resend)*

------
https://chatgpt.com/codex/tasks/task_e_68b64bfc5ecc8324a20f26e08abcca12