### PR TITLE
イベント詳細の会場/備考非表示と一覧のサムネイル画像復活

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -16,7 +16,6 @@ import { nanoid } from "nanoid";
 import { updateParticipantCount } from "@/lib/updateParticipantCount";
 import { updateSeatReservedCount } from "@/lib/updateSeatReservedCount";
 import type { Event, Seat } from "@/types";
-import { linkifyAndLineBreak } from "@/lib/text";
 import { stripBlobImages } from "@/utils/url";
 import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
 
@@ -225,20 +224,6 @@ export default function EventDetailPage() {
           dangerouslySetInnerHTML={{ __html: stripBlobImages(event.greeting) }}
         />
       )}
-      {event.venues && event.venues.length === 1 ? (
-        <p>
-          会場: <span dangerouslySetInnerHTML={{ __html: stripBlobImages(linkifyAndLineBreak(event.venues[0])) }} />
-        </p>
-      ) : event.venues && event.venues.length > 1 ? (
-        <div className="mb-2">
-          <p>会場:</p>
-          <ul className="list-disc pl-5">
-            {event.venues.map((v, i) => (
-              <li key={i} dangerouslySetInnerHTML={{ __html: stripBlobImages(linkifyAndLineBreak(v)) }} />
-            ))}
-          </ul>
-        </div>
-      ) : null}
       <p>日付: {event.date.toDate().toLocaleDateString("ja-JP")}</p>
       <p className="mb-4">説明: {event.description}</p>
 
@@ -333,7 +318,6 @@ export default function EventDetailPage() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white p-6 rounded space-y-4 text-lg max-w-sm w-full">
             <h2 className="text-xl font-bold">ご予約内容の確認</h2>
-            <p>会場: {(event?.venues || []).join(" / ")}</p>
             <p>日付: {event?.date.toDate().toLocaleDateString("ja-JP")}</p>
             {event?.seats && event.seats.length > 0 && (
               <p>時間: {selectedTime}</p>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -6,6 +6,7 @@ import { db } from "@/lib/firebase";
 import { collection, getDocs } from "firebase/firestore";
 import type { EventSummary, Seat } from "@/types";
 import LinkBackToHome from "@/components/LinkBackToHome";
+import { extractFirstImageSrc } from "@/lib/extractFirstImage";
  
 
 export default function EventsPage() {
@@ -26,6 +27,7 @@ export default function EventsPage() {
             rawDate: d.date?.toDate() as Date,
             cost: d.cost,
             description: d.description,
+            greetingHtml: d.greeting || null,
             participants: (d.seats as Seat[] | undefined)?.reduce(
               (sum: number, seat) => sum + (seat.reserved || 0),
               0
@@ -51,6 +53,7 @@ export default function EventsPage() {
             }),
             cost: ev.cost,
             description: ev.description,
+            greetingHtml: ev.greetingHtml,
             participants: ev.participants,
             capacity: ev.capacity,
           } as EventSummary;
@@ -65,35 +68,47 @@ export default function EventsPage() {
       <LinkBackToHome />
       <h1 className="text-2xl font-bold text-center mb-6">お茶会のご案内</h1>
       <div className="space-y-8">
-        {events.map((event) => (
-          <div
-            key={event.id}
-            className="p-6 border rounded-lg shadow-lg bg-white hover:shadow-xl transition-shadow"
-          >
-            <h2 className="text-xl font-bold mb-2">{event.title}</h2>
-            <p className="mb-1 font-semibold">
-              会場: <span className="font-normal">{event.venue}</span>
-            </p>
-            <p className="mb-1 font-semibold">
-              日時: <span className="font-normal">{event.date}</span>
-            </p>
-            <p className="mb-1 font-semibold">
-              参加費用: <span className="font-normal">{event.cost}円</span>
-            </p>
-            <p className="mb-3 font-semibold">
-              参加人数:
-              <span className="font-normal">
-                {event.participants}/{event.capacity}人
-              </span>
-            </p>
-            <p className="mb-4">{event.description}</p>
-            <Link href={`/events/${event.id}`}>
-              <button className="w-32 mx-auto block bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 rounded shadow transition-colors font-serif">
-                予約する
-              </button>
-            </Link>
-          </div>
-        ))}
+        {events.map((event) => {
+          const thumb = extractFirstImageSrc(event.greetingHtml);
+          return (
+            <article
+              key={event.id}
+              className={`p-6 border rounded-lg shadow-lg bg-white hover:shadow-xl transition-shadow grid gap-4 ${
+                thumb ? "md:grid-cols-[1fr_260px]" : ""
+              }`}
+            >
+              <div>
+                <h2 className="text-xl font-bold mb-2">{event.title}</h2>
+                <p className="mb-1 font-semibold">
+                  会場: <span className="font-normal">{event.venue}</span>
+                </p>
+                <p className="mb-1 font-semibold">
+                  日時: <span className="font-normal">{event.date}</span>
+                </p>
+                <p className="mb-1 font-semibold">
+                  参加費用: <span className="font-normal">{event.cost}円</span>
+                </p>
+                <p className="mb-3 font-semibold">
+                  参加人数:
+                  <span className="font-normal">
+                    {event.participants}/{event.capacity}人
+                  </span>
+                </p>
+                <p className="mb-4">{event.description}</p>
+                <Link href={`/events/${event.id}`}>
+                  <button className="w-32 mx-auto block bg-[#C1A46F] hover:bg-[#A88C5A] text-white py-2 rounded shadow transition-colors font-serif">
+                    予約する
+                  </button>
+                </Link>
+              </div>
+              {thumb ? (
+                <div className="relative w-full aspect-[4/3] overflow-hidden rounded-md">
+                  <img src={thumb} alt="" className="h-full w-full object-cover" />
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
       </div>
     </main>
   );

--- a/lib/extractFirstImage.ts
+++ b/lib/extractFirstImage.ts
@@ -1,0 +1,5 @@
+export function extractFirstImageSrc(html?: string | null): string | null {
+  if (!html) return null;
+  const m = html.match(/<img[^>]+src=['"]([^'"]+)['"]/i);
+  return m?.[1] ?? null;
+}

--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,7 @@ export interface EventSummary {
   description?: string;
   participants?: number;
   capacity?: number;
+  greetingHtml?: string | null;
 }
 
 export interface Reservation {


### PR DESCRIPTION
## Summary
- ごあいさつHTMLから1枚目の画像を抽出するユーティリティを追加
- イベント一覧で先頭画像をサムネイル表示（画像なしの場合は非表示）
- イベント詳細ページから会場と備考の表示を削除

## Testing
- `npm test` (missing script: test)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6611e87348324b2ecff00cfcb6d8b