### PR TITLE
fix: ensure event thumbnails render reliably

### DIFF
--- a/lib/extractFirstImage.ts
+++ b/lib/extractFirstImage.ts
@@ -1,7 +1,16 @@
 export function extractFirstImageSrc(html?: string | null): string | null {
   if (!html) return null;
-  // ・シングル/ダブル両対応  ・属性順不同  ・改行/空白ありでもOK
-  // 例: <img ... src="..." ...> / <img\nsrc='...'>
+
+  // 1) 正規表現（シングル/ダブル、改行、属性順不同に対応）
   const m = html.match(/<img\b[^>]*?\bsrc=(['"])(.*?)\1/i);
-  return m?.[2] ?? null;
+  if (m?.[2]) return m[2];
+
+  // 2) DOM パースでのフォールバック（ブラウザ側）
+  if (typeof window !== "undefined") {
+    const div = document.createElement("div");
+    div.innerHTML = html;
+    const img = div.querySelector("img");
+    return img?.getAttribute("src") ?? null;
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
- extract first greeting image via regex with DOM fallback
- verify event detail page no longer renders venue/date/description lines outside modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b675a66e34832494ca12717fc8d6fa