### PR TITLE
席指定を設定できるようにする

### DIFF
--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -82,7 +82,9 @@ export default function EditEventPage() {
   }, [paramId, eventId]);
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >,
     index?: number
   ) => {
     const { name, value } = e.target;
@@ -90,7 +92,12 @@ export default function EditEventPage() {
       const updatedSeats = [...form.seats];
       const seat = { ...updatedSeats[index] };
       if (name === "seatType") {
-        seat.time = value === "tentative" ? TENTATIVE_LABEL : "08:00";
+        seat.time =
+          value === "tentative"
+            ? TENTATIVE_LABEL
+            : value === "seat"
+            ? ""
+            : "08:00";
       }
       if (name === "hour") {
         const minute = seat.time.includes(":") ? seat.time.split(":")[1] : "00";
@@ -99,6 +106,9 @@ export default function EditEventPage() {
       if (name === "minute") {
         const hour = seat.time.includes(":") ? seat.time.split(":")[0] : "08";
         seat.time = `${hour}:${value}`;
+      }
+      if (name === "label") {
+        seat.time = value;
       }
       if (name === "capacity") {
         seat.capacity = Number(value);
@@ -136,8 +146,14 @@ export default function EditEventPage() {
 
   const sortSeats = (seats: Seat[]) =>
     [...seats].sort((a, b) => {
+      const isTime = (t: string) => /^\d{2}:\d{2}$/.test(t);
       if (a.time === TENTATIVE_LABEL) return 1;
       if (b.time === TENTATIVE_LABEL) return -1;
+      const aIsTime = isTime(a.time);
+      const bIsTime = isTime(b.time);
+      if (aIsTime && bIsTime) return a.time.localeCompare(b.time);
+      if (aIsTime) return -1;
+      if (bIsTime) return 1;
       return a.time.localeCompare(b.time);
     });
 
@@ -306,10 +322,14 @@ export default function EditEventPage() {
         </div>
 
         <div className="space-y-2">
-          <p className="font-semibold">時間枠と定員（複数設定可）</p>
+          <p className="font-semibold">時間枠/席と定員（複数設定可）</p>
           {form.seats.map((seat, i) => {
             const [h, m] = seat.time.includes(":") ? seat.time.split(":") : ["08", "00"];
-            const seatType = seat.time === TENTATIVE_LABEL ? "tentative" : "time";
+            const seatType = seat.time === TENTATIVE_LABEL
+              ? "tentative"
+              : seat.time.includes(":")
+              ? "time"
+              : "seat";
             return (
               <div key={i} className="flex gap-2 items-center">
                 <select
@@ -319,6 +339,7 @@ export default function EditEventPage() {
                   className="border p-2"
                 >
                   <option value="time">時間指定</option>
+                  <option value="seat">席指定</option>
                   <option value="tentative">仮予約</option>
                 </select>
                 {seatType === "time" && (
@@ -348,6 +369,17 @@ export default function EditEventPage() {
                       ))}
                     </select>
                   </>
+                )}
+                {seatType === "seat" && (
+                  <input
+                    type="text"
+                    name="label"
+                    value={seat.time}
+                    onChange={(e) => handleChange(e, i)}
+                    maxLength={5}
+                    className="border p-2 w-20"
+                    placeholder="席名"
+                  />
                 )}
                 <select
                   name="capacity"

--- a/app/admin/events/[id]/reservations/page.tsx
+++ b/app/admin/events/[id]/reservations/page.tsx
@@ -76,7 +76,7 @@ export default function EventReservationsPage() {
     const seat = (event.seats as Seat[]).find(
       (s) => s.time === editForm.seatTime
     );
-    if (!seat) return alert("時間枠が無効です");
+    if (!seat) return alert("時間枠または席が無効です");
 
     const reservationSnapshot = await getDocs(
       query(
@@ -143,7 +143,7 @@ export default function EventReservationsPage() {
                     onChange={(e) => setEditForm({ ...editForm, seatTime: e.target.value })}
                     className="border p-2 w-full"
                   >
-                    <option value="">時間を選択</option>
+                    <option value="">時間または席を選択</option>
                     {availableTimes.map((time) => (
                       <option key={time} value={time}>
                         {time}
@@ -180,7 +180,7 @@ export default function EventReservationsPage() {
                     <p className="font-semibold">
                       👤 {res.name}（{res.guests}名）
                     </p>
-                    <p className="text-sm text-gray-500">時間枠: {res.seatTime}</p>
+                    <p className="text-sm text-gray-500">時間/席: {res.seatTime}</p>
                     <p className="text-sm text-gray-500">
                       住所: {res.address || "(未入力)"}
                     </p>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -115,7 +115,7 @@ export default function UserListPage() {
     const seats = eventSeatMap[eventId];
     const selectedSeat = seats.find((s: Seat) => s.time === editForm.seatTime);
     if (!selectedSeat) {
-      alert("選択された時間枠が無効です");
+      alert("選択された時間枠または席が無効です");
       return;
     }
 
@@ -155,7 +155,7 @@ export default function UserListPage() {
             <th className="border px-2 py-1">住所</th>
             <th className="border px-2 py-1">人数</th>
             <th className="border px-2 py-1">イベント名</th>
-            <th className="border px-2 py-1">時間枠</th>
+            <th className="border px-2 py-1">時間/席</th>
             <th className="border px-2 py-1">予約日時</th>
             <th className="border px-2 py-1">操作</th>
           </tr>
@@ -216,7 +216,7 @@ export default function UserListPage() {
                     value={editForm.seatTime}
                     onChange={(e) => setEditForm({ ...editForm, seatTime: e.target.value })}
                   >
-                    <option value="">時間を選択</option>
+                    <option value="">時間または席を選択</option>
                     {(eventSeatTimes[r.eventId] || []).map((time) => (
                       <option key={time} value={time}>{time}</option>
                     ))}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -67,7 +67,7 @@ export default function EventDetailPage() {
     const seat = (event.seats as Seat[]).find((s) => s.time === selectedTime);
     if (event.seats && event.seats.length > 0) {
       if (!seat) {
-        alert("選択された時間枠が無効です");
+        alert("選択された時間枠または席が無効です");
         return;
       }
 
@@ -188,7 +188,7 @@ export default function EventDetailPage() {
               <li><strong>日付:</strong> ${event.date
                 .toDate()
                 .toLocaleDateString("ja-JP")}</li>
-              <li><strong>時間:</strong> ${selectedTime || "時間指定なし"}</li>
+              <li><strong>時間/席:</strong> ${selectedTime || "時間指定なし"}</li>
               <li><strong>人数:</strong> ${guests}名</li>
               <li><strong>メール:</strong> ${email}</li>
               <li><strong>住所:</strong> ${address || "(未入力)"}</li>
@@ -275,14 +275,14 @@ export default function EventDetailPage() {
         </div>
         {event.seats && event.seats.length > 0 && (
           <div>
-            <label className="block mb-1">時間枠選択</label>
+            <label className="block mb-1">時間枠/席選択</label>
             <select
               className="border p-2 w-full"
               value={selectedTime}
               onChange={(e) => setSelectedTime(e.target.value)}
               required
             >
-              <option value="">時間を選択</option>
+              <option value="">時間または席を選択</option>
               {(event.seats as Seat[]).map((seat) => (
                 <option
                   key={seat.time}
@@ -321,7 +321,7 @@ export default function EventDetailPage() {
             <h2 className="text-xl font-bold">ご予約内容の確認</h2>
             <p>日付: {event?.date.toDate().toLocaleDateString("ja-JP")}</p>
             {event?.seats && event.seats.length > 0 && (
-              <p>時間: {selectedTime}</p>
+              <p>時間/席: {selectedTime}</p>
             )}
             {address && <p>住所: {address}</p>}
             <p>人数: {guests}名</p>

--- a/app/reservations/confirm/page.tsx
+++ b/app/reservations/confirm/page.tsx
@@ -55,7 +55,7 @@ export default function ReservationConfirmPage() {
     const seat = (event.seats as Seat[]).find(
       (s) => s.time === original.seatTime
     );
-    if (!seat) return alert("時間枠が無効です");
+    if (!seat) return alert("時間枠または席が無効です");
 
     const reservationSnapshot = await getDocs(
       query(
@@ -122,7 +122,7 @@ export default function ReservationConfirmPage() {
       {reservations.map((r) => (
         <div key={r.id} className="border rounded p-4 mb-4 shadow">
           <p>イベントID: {r.eventId}</p>
-          <p>時間枠: {r.seatTime || "時間指定なし"}</p>
+          <p>時間/席: {r.seatTime || "時間指定なし"}</p>
           <p>人数: {r.guests}</p>
           <p>住所: {r.address || "(未入力)"}</p>
           <input

--- a/lib/updateSeatReservedCount.ts
+++ b/lib/updateSeatReservedCount.ts
@@ -10,7 +10,7 @@ import {
   getDoc,
 } from "firebase/firestore";
 
-// 特定のイベントの各時間枠ごとの予約数（reserved）を集計し直す
+// 特定のイベントの各時間枠/席ごとの予約数（reserved）を集計し直す
 export const updateSeatReservedCount = async (eventId: string) => {
   const eventRef = doc(db, "events", eventId);
   const eventSnap = await getDoc(eventRef);

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,5 @@
 export interface Seat {
+  /** 時刻 (HH:mm) または席名 */
   time: string;
   capacity: number;
   reserved?: number;


### PR DESCRIPTION
## 概要
- イベント編集画面で時間指定/仮予約に加えて席指定を追加
- 予約フォームや管理画面の文言を時間枠/席に対応
- Seat 型の time に席名も格納できるようコメントを追加

## テスト
- `npm test` (スクリプト未定義のため失敗)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b84c203a188324b9af5f6f773b8d8f