### PR TITLE
事務局連絡先メールアドレスの更新

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -165,7 +165,7 @@ export default function EventDetailPage() {
             </div>
             <hr/>
             <p>当日お会いできますことを、心より楽しみにしております。</p>
-            <p>ご不明点などございましたら、事務局の神田まで（メール：kandatoshi1@gmail.com）お気軽にご連絡ください。</p>
+            <p>ご不明点などございましたら、事務局まで（メール：sekishuryu-nomuraha@googlegroups.com）お気軽にご連絡ください。</p>
           </div>
         `,
       }),


### PR DESCRIPTION
## Summary
- 申し込み案内の連絡先を神田の個人アドレスから事務局のメーリングリストに変更

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b90875494483248467d08d8291089a