### PR TITLE
メール注意書き追加とCSVダウンロード、管理画面ライトモード化

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,9 +3,12 @@ import EnsureAdminCookie from "@/components/EnsureAdminCookie";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
-    <>
+    <div
+      className="bg-white text-black min-h-screen"
+      style={{ colorScheme: "light" }}
+    >
       <EnsureAdminCookie />
       {children}
-    </>
+    </div>
   );
 }

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -190,13 +190,53 @@ export default function UserListPage() {
     return [main, ...companions];
   });
 
+  const handleDownloadCsv = () => {
+    const headers = [
+      "申込代表者",
+      "同席者",
+      "メールアドレス",
+      "住所",
+      "人数",
+      "イベント名",
+      "時間/席",
+      "予約日時",
+    ];
+    const rows = displayReservations.map((r) => [
+      r.representative,
+      r.companion,
+      r.isCompanion ? "" : r.email ?? "",
+      r.isCompanion ? "" : r.address || "",
+      r.isCompanion ? "" : r.guests,
+      r.isCompanion ? "" : eventTitles[r.eventId || ""] || "",
+      r.isCompanion ? "" : r.seatTime || "",
+      format(new Date(r.createdAt), "yyyy/M/d HH:mm:ss", { locale: ja }),
+    ]);
+    const csv = [headers, ...rows]
+      .map((row) =>
+        row.map((f) => `"${String(f ?? "").replace(/"/g, '""')}"`).join(",")
+      )
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "reservations.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <main className="p-6 max-w-5xl mx-auto">
       <Link href="/admin" className="text-blue-600 underline block mb-4">
         ← 管理ダッシュボードに戻る
       </Link>
       <h1 className="text-2xl font-bold mb-4">全予約者一覧</h1>
-
+      <button
+        onClick={handleDownloadCsv}
+        className="bg-blue-600 text-white px-4 py-2 rounded mb-4"
+      >
+        CSVダウンロード
+      </button>
       <table className="w-full border text-sm shadow-md bg-white">
         <thead>
           <tr className="bg-gray-100">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -256,6 +256,9 @@ export default function EventDetailPage() {
         </div>
         <div>
           <label className="block mb-1">メールアドレス</label>
+          <p className="text-sm text-gray-600 mb-1">
+            キャリアメール（docomo, au, softbank等）をご利用の場合、迷惑メール設定により確認メールが届かないことがありますため、Gmail等のアドレスをご利用ください。
+          </p>
           <input
             type="email"
             className="border p-2 w-full"


### PR DESCRIPTION
## Summary
- 予約フォームにキャリアメール利用時の注意書きを追加
- 予約者一覧からCSVをダウンロードできるボタンを追加
- 管理者画面を常にライトモードで表示するよう変更

## Testing
- `npm test` (missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c13e30cfa88324ba1287696d35b5ec