### PR TITLE
Group admin reservations by event and enable sorting

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -257,7 +257,14 @@ export default function EventDetailPage() {
         <div>
           <label className="block mb-1">メールアドレス</label>
           <p className="text-sm text-gray-600 mb-1">
-            キャリアメール（docomo, au, softbank等）をご利用の場合、迷惑メール設定により確認メールが届かないことがありますため、Gmail等のアドレスをご利用を推奨しております。予約後に確認メールが届かない場合はsekishuryu-nomuraha@googlegroups.comまでご連絡ください。
+            キャリアメール（docomo, au, softbank等）をご利用の場合、迷惑メール設定により確認メールが届かないことがありますため、Gmail等のアドレスをご利用を推奨しております。予約後に確認メールが届かない場合は
+            <a
+              href="mailto:sekishuryu-nomuraha@googlegroups.com"
+              className="text-blue-600 underline"
+            >
+              sekishuryu-nomuraha@googlegroups.com
+            </a>
+            までご連絡ください。
           </p>
           <input
             type="email"


### PR DESCRIPTION
## Summary
- turn the contact email on the reservation form into a mailto link so it opens the default mail client
- group the admin reservation list by event with collapsible sections and add sorting controls for reservation time and seat/time

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e049d15c83249781febfbf7f3c50