### PR TITLE
カルーセル画像の複数登録とプレビュー画面の追加

### DIFF
--- a/app/admin2/page.tsx
+++ b/app/admin2/page.tsx
@@ -19,6 +19,13 @@ export default function AdminDashboard() {
         </div>
         <div
           className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
+          onClick={() => router.push("/admin2/top-image/preview")}
+        >
+          <h2 className="text-xl font-semibold mb-2">👀 トップ画像プレビュー</h2>
+          <p>お客様向け表示に近いカルーセルを確認します</p>
+        </div>
+        <div
+          className="border rounded p-4 shadow-md hover:bg-gray-50 cursor-pointer bg-white"
           onClick={() => router.push("/admin2/greeting")}
         >
           <h2 className="text-xl font-semibold mb-2">💬 ごあいさつ設定</h2>

--- a/app/admin2/top-image/page.tsx
+++ b/app/admin2/top-image/page.tsx
@@ -5,7 +5,7 @@ import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
 
 export default function TopImagePage() {
   return (
-    <main className="p-6 max-w-xl mx-auto">
+    <main className="p-6 max-w-4xl mx-auto">
       <LinkBackToAdmin2Top />
       <AdminTopImageSettings />
     </main>

--- a/app/admin2/top-image/preview/page.tsx
+++ b/app/admin2/top-image/preview/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import GalleryCarousel from "@/components/GalleryCarousel";
+import LinkBackToAdmin2Top from "@/components/LinkBackToAdmin2Top";
+import { db } from "@/lib/firebase";
+import type { HeroImageSetting } from "@/types";
+import { doc, getDoc } from "firebase/firestore";
+
+type CarouselImage = {
+  src: string;
+  alt?: string;
+};
+
+export default function TopImagePreviewPage() {
+  const [images, setImages] = useState<CarouselImage[]>([]);
+
+  useEffect(() => {
+    const fetchImages = async () => {
+      let ref = doc(db, "settings", "publicSite");
+      let snap = await getDoc(ref);
+      if (!snap.exists()) {
+        ref = doc(db, "settings", "site");
+        snap = await getDoc(ref);
+      }
+      if (!snap.exists()) return;
+
+      const data = snap.data();
+      const heroImages = Array.isArray(data.heroImages)
+        ? (data.heroImages as HeroImageSetting[])
+        : [];
+
+      if (heroImages.length > 0) {
+        setImages(
+          heroImages
+            .filter((img) => typeof img?.url === "string")
+            .map((img) => ({ src: img.url, alt: img.alt }))
+        );
+        return;
+      }
+
+      if (typeof data.heroImageUrl === "string" && data.heroImageUrl) {
+        setImages([
+          {
+            src: data.heroImageUrl,
+            alt: typeof data.heroImageAlt === "string" ? data.heroImageAlt : undefined,
+          },
+        ]);
+      }
+    };
+
+    fetchImages();
+  }, []);
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto space-y-6">
+      <LinkBackToAdmin2Top />
+      <div>
+        <h1 className="text-2xl font-bold mb-2">トップ画像カルーセル プレビュー</h1>
+        <p className="text-sm text-gray-600">
+          現在登録されている画像をお客様向けの表示に近い形で確認できます。
+        </p>
+      </div>
+      {images.length > 0 ? (
+        <GalleryCarousel images={images} autoPlayMs={5000} />
+      ) : (
+        <p className="text-sm text-gray-500">
+          まだ画像が登録されていません。設定ページから画像を追加してください。
+        </p>
+      )}
+    </main>
+  );
+}

--- a/components/AdminTopImageSettings.tsx
+++ b/components/AdminTopImageSettings.tsx
@@ -1,93 +1,207 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
-import { db } from "@/lib/firebase";
+import Link from "next/link";
 import { doc, getDoc, setDoc } from "firebase/firestore";
+
+import { db } from "@/lib/firebase";
 import { uploadImageToStorage } from "@/lib/storageImages";
 import { validateImage } from "@/lib/validateImage";
-import { isUnsafeImageSrc } from "@/utils/url";
+
+type ExistingImageItem = {
+  id: string;
+  type: "existing";
+  url: string;
+  alt: string;
+  storagePath?: string;
+};
+
+type NewImageItem = {
+  id: string;
+  type: "new";
+  file: File;
+  preview: string;
+  alt: string;
+};
+
+type ImageItem = ExistingImageItem | NewImageItem;
+
+const STORAGE_PATH = "images/hero";
+
+const createId = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
 export default function AdminTopImageSettings() {
-  const [imageUrl, setImageUrl] = useState("");
-  const [alt, setAlt] = useState("");
-  const [storagePath, setStoragePath] = useState("");
-  const [file, setFile] = useState<File | null>(null);
-  const [previewUrl, setPreviewUrl] = useState("");
+  const [items, setItems] = useState<ImageItem[]>([]);
   const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const itemsRef = useRef<ImageItem[]>([]);
 
   useEffect(() => {
-    const fetchImage = async () => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    const fetchImages = async () => {
       let refDoc = doc(db, "settings", "publicSite");
       let snap = await getDoc(refDoc);
       if (!snap.exists()) {
         refDoc = doc(db, "settings", "site");
         snap = await getDoc(refDoc);
       }
-      if (snap.exists()) {
-        const data = snap.data();
-        if (data.heroImageUrl) setImageUrl(data.heroImageUrl);
-        if (data.heroImageAlt) setAlt(data.heroImageAlt);
-        if (data.heroImageStoragePath) setStoragePath(data.heroImageStoragePath);
+      if (!snap.exists()) return;
+      const data = snap.data();
+      const heroImagesRaw = Array.isArray(data.heroImages)
+        ? (data.heroImages as { url?: string; alt?: string; storagePath?: string }[])
+        : [];
+      const normalized: ExistingImageItem[] = heroImagesRaw
+        .filter((img) => typeof img?.url === "string")
+        .map((img) => ({
+          id: createId(),
+          type: "existing",
+          url: img.url as string,
+          alt: img.alt ?? "",
+          storagePath: img.storagePath,
+        }));
+
+      if (normalized.length > 0) {
+        setItems(normalized);
+        return;
+      }
+
+      if (typeof data.heroImageUrl === "string" && data.heroImageUrl) {
+        setItems([
+          {
+            id: createId(),
+            type: "existing",
+            url: data.heroImageUrl,
+            alt: typeof data.heroImageAlt === "string" ? data.heroImageAlt : "",
+            storagePath:
+              typeof data.heroImageStoragePath === "string"
+                ? data.heroImageStoragePath
+                : undefined,
+          },
+        ]);
       }
     };
-    fetchImage();
+
+    fetchImages();
   }, []);
 
-  const handleFileChange = (f: File) => {
-    if (!validateImage(f)) return;
-    setFile(f);
-    setPreviewUrl((p) => {
-      if (p) URL.revokeObjectURL(p);
-      return URL.createObjectURL(f);
-    });
-  };
+  useEffect(() => {
+    return () => {
+      itemsRef.current.forEach((item) => {
+        if (item.type === "new") URL.revokeObjectURL(item.preview);
+      });
+    };
+  }, []);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0];
-    if (f) handleFileChange(f);
+  const addFiles = (files: FileList | File[]) => {
+    const list = Array.from(files ?? []);
+    if (list.length === 0) return;
+    const newItems: ImageItem[] = [];
+    for (const file of list) {
+      if (!validateImage(file)) continue;
+      const preview = URL.createObjectURL(file);
+      const baseName = file.name.replace(/\.[^.]+$/, "");
+      newItems.push({
+        id: createId(),
+        type: "new",
+        file,
+        preview,
+        alt: baseName,
+      });
+    }
+    if (newItems.length > 0) {
+      setItems((prev) => [...prev, ...newItems]);
+    }
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
-    const f = e.dataTransfer.files?.[0];
-    if (f) handleFileChange(f);
+    if (e.dataTransfer.files) {
+      addFiles(e.dataTransfer.files);
+    }
   };
 
-  useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-    };
-  }, [previewUrl]);
+  const removeItem = (id: string) => {
+    setItems((prev) => {
+      const target = prev.find((item) => item.id === id);
+      if (target && target.type === "new") {
+        URL.revokeObjectURL(target.preview);
+      }
+      return prev.filter((item) => item.id !== id);
+    });
+  };
+
+  const moveItem = (id: string, direction: "up" | "down") => {
+    setItems((prev) => {
+      const index = prev.findIndex((item) => item.id === id);
+      if (index === -1) return prev;
+      const targetIndex = direction === "up" ? index - 1 : index + 1;
+      if (targetIndex < 0 || targetIndex >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+      return next;
+    });
+  };
+
+  const handleAltChange = (id: string, alt: string) => {
+    setItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, alt } : item))
+    );
+  };
 
   const handleSave = async () => {
+    const snapshot = [...items];
     setUploading(true);
+    const newItems = snapshot.filter((item): item is NewImageItem => item.type === "new");
     try {
-      let downloadUrl = imageUrl;
-      let path = storagePath;
-      if (file) {
-        const { url, path: uploadedPath } = await uploadImageToStorage(
-          file,
-          "images/hero",
-          { uploadedBy: "admin" }
-        );
-        downloadUrl = url;
-        path = uploadedPath;
+      const saved = [] as {
+        url: string;
+        alt: string;
+        storagePath?: string;
+      }[];
+      for (const item of snapshot) {
+        if (item.type === "existing") {
+          saved.push({
+            url: item.url,
+            alt: item.alt,
+            storagePath: item.storagePath,
+          });
+          continue;
+        }
+        const { url, path } = await uploadImageToStorage(item.file, STORAGE_PATH, {
+          uploadedBy: "admin",
+        });
+        saved.push({
+          url,
+          alt: item.alt,
+          storagePath: path,
+        });
       }
+
       await setDoc(
         doc(db, "settings", "publicSite"),
         {
-          heroImageUrl: downloadUrl,
-          heroImageAlt: alt,
-          heroImageStoragePath: path,
+          heroImages: saved,
+          heroImageUrl: saved[0]?.url ?? "",
+          heroImageAlt: saved[0]?.alt ?? "",
+          heroImageStoragePath: saved[0]?.storagePath ?? "",
         },
         { merge: true }
       );
-      setImageUrl(downloadUrl);
-      setStoragePath(path);
-      setFile(null);
-      setPreviewUrl("");
+
+      const normalized: ExistingImageItem[] = saved.map((img) => ({
+        id: createId(),
+        type: "existing",
+        url: img.url,
+        alt: img.alt,
+        storagePath: img.storagePath,
+      }));
+
+      newItems.forEach((item) => URL.revokeObjectURL(item.preview));
+      setItems(normalized);
       alert("保存しました");
     } catch (err) {
       console.error(err);
@@ -97,41 +211,107 @@ export default function AdminTopImageSettings() {
     }
   };
 
+  const hasImages = items.length > 0;
+
+  const dropText = useMemo(() => {
+    if (!hasImages) return "ここにドラッグ＆ドロップまたはクリックして画像を追加";
+    return "追加の画像をドラッグ＆ドロップまたはクリックで選択";
+  }, [hasImages]);
+
   return (
-    <div className="p-6 max-w-xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">トップページ画像設定</h1>
-      {(previewUrl || imageUrl) &&
-        !isUnsafeImageSrc(previewUrl || imageUrl) && (
-          <Image
-            src={previewUrl || imageUrl}
-            alt="プレビュー"
-            width={800}
-            height={600}
-            className="w-full h-auto mb-4 rounded"
-          />
-        )}
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">トップページ画像設定</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        複数枚の画像を登録してカルーセル表示できます。表示順は上から順番になります。
+      </p>
       <div
-        className="border-2 border-dashed p-4 text-center mb-4 cursor-pointer"
+        className="border-2 border-dashed border-gray-300 rounded p-6 text-center mb-6 cursor-pointer bg-white"
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
         onClick={() => inputRef.current?.click()}
       >
-        {file ? file.name : "ここにドラッグ＆ドロップまたはクリックして選択"}
+        <p className="text-sm text-gray-600">{dropText}</p>
+        <p className="text-xs text-gray-400 mt-1">jpg / jpeg / png / webp / gif ・ 10MB まで</p>
         <input
           type="file"
           accept="image/*"
+          multiple
           ref={inputRef}
           className="hidden"
-          onChange={handleInputChange}
+          onChange={(e) => {
+            if (e.target.files) addFiles(e.target.files);
+            if (e.target) e.target.value = "";
+          }}
         />
       </div>
-      <input
-        type="text"
-        value={alt}
-        onChange={(e) => setAlt(e.target.value)}
-        placeholder="画像の説明 (alt)"
-        className="w-full p-2 border rounded mb-4"
-      />
+
+      <div className="space-y-4 mb-6">
+        {items.map((item, index) => (
+          <div
+            key={item.id}
+            className="flex flex-col sm:flex-row gap-4 border rounded-lg p-4 bg-gray-50"
+          >
+            <div className="relative w-full sm:w-56 h-40 flex-shrink-0 overflow-hidden rounded">
+              {item.type === "existing" ? (
+                <Image src={item.url} alt="カルーセル画像" fill className="object-cover" />
+              ) : (
+                <Image
+                  src={item.preview}
+                  alt={item.file.name}
+                  fill
+                  unoptimized
+                  className="object-cover"
+                />
+              )}
+            </div>
+            <div className="flex-1 space-y-2">
+              <div>
+                <label className="block text-sm font-medium">代替テキスト (alt)</label>
+                <input
+                  type="text"
+                  value={item.alt}
+                  onChange={(e) => handleAltChange(item.id, e.target.value)}
+                  className="w-full mt-1 p-2 border rounded"
+                />
+              </div>
+              {item.type === "existing" && (
+                <p className="text-xs text-gray-500 break-all">{item.url}</p>
+              )}
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="text-xs text-blue-600 disabled:text-gray-400"
+                  onClick={() => moveItem(item.id, "up")}
+                  disabled={index === 0}
+                >
+                  ↑ 上へ
+                </button>
+                <button
+                  type="button"
+                  className="text-xs text-blue-600 disabled:text-gray-400"
+                  onClick={() => moveItem(item.id, "down")}
+                  disabled={index === items.length - 1}
+                >
+                  ↓ 下へ
+                </button>
+                <button
+                  type="button"
+                  className="text-xs text-red-600"
+                  onClick={() => removeItem(item.id)}
+                >
+                  削除
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+        {!hasImages && (
+          <p className="text-sm text-gray-500">
+            まだ画像が登録されていません。上の枠から画像を追加してください。
+          </p>
+        )}
+      </div>
+
       <button
         onClick={handleSave}
         disabled={uploading}
@@ -139,6 +319,12 @@ export default function AdminTopImageSettings() {
       >
         {uploading ? "保存中..." : "保存"}
       </button>
+      <Link
+        href="/admin2/top-image/preview"
+        className="text-sm text-blue-600 underline hover:text-blue-800 mt-4 block"
+      >
+        カルーセルのプレビューを見る
+      </Link>
     </div>
   );
 }

--- a/types.ts
+++ b/types.ts
@@ -56,10 +56,17 @@ export interface GreetingLine {
   font: "serif" | "sans" | "mono";
 }
 
+export interface HeroImageSetting {
+  url: string;
+  alt?: string;
+  storagePath?: string;
+}
+
 export interface PublicSiteSettings {
   heroImageUrl?: string;
   heroImageAlt?: string;
   heroImageStoragePath?: string;
+  heroImages?: HeroImageSetting[];
   paragraphs?: string[];
 }
 


### PR DESCRIPTION
## Summary
- トップ画像設定画面をカルーセル複数枚の追加・並べ替え・削除に対応
- 保存時にFirestoreへカルーセル画像リストを保存し既存形式とも互換を維持
- 管理ダッシュボードにカルーセルのプレビュー画面へのリンクカードを追加し、プレビュー用ページを実装

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5e48389608324a067ba4bbed60256