### PR TITLE
Add public tea history pages with carousel support

### DIFF
--- a/app/tea-history/[id]/page.tsx
+++ b/app/tea-history/[id]/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Image from "next/image";
+import LinkBackToHome from "@/components/LinkBackToHome";
+import GalleryCarousel from "@/components/GalleryCarousel";
+import RichHtml from "@/components/RichHtml";
+import { db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import type { BlogPost } from "@/types";
+import { deltaToHtml } from "@/lib/quillDelta";
+import { isUnsafeImageSrc, stripBlobImages } from "@/utils/url";
+import { preserveLeadingSpaces } from "@/lib/preserveLeadingSpaces";
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  const hasTime = value.includes("T");
+  const date = new Date(hasTime ? value : `${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("ja-JP");
+}
+
+export default function TeaHistoryDetailPage() {
+  const { id } = useParams();
+  const [post, setPost] = useState<BlogPost | null>(null);
+  const [html, setHtml] = useState("");
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      if (!id) return;
+      const ref = doc(db, "teaArchives", id as string);
+      const snap = await getDoc(ref);
+      if (snap.exists()) {
+        setPost({ id: snap.id, ...(snap.data() as Omit<BlogPost, "id">) });
+      }
+    };
+    fetchPost();
+  }, [id]);
+
+  useEffect(() => {
+    if (!post) return;
+    if (post.bodyDelta) {
+      setHtml(preserveLeadingSpaces(deltaToHtml(post.bodyDelta)));
+    } else if (post.bodyHtmlUrl) {
+      fetch(post.bodyHtmlUrl)
+        .then(res => res.text())
+        .then(t => setHtml(preserveLeadingSpaces(t)))
+        .catch(() => setHtml(preserveLeadingSpaces(post.body || "")));
+    } else {
+      setHtml(preserveLeadingSpaces(post.body || ""));
+    }
+  }, [post]);
+
+  const galleryImages = useMemo(() => {
+    return (post?.galleryImages ?? [])
+      .filter(url => !isUnsafeImageSrc(url))
+      .map(url => ({ src: url, alt: post?.title ?? "" }));
+  }, [post]);
+
+  if (!post) {
+    return <p className="p-6 font-serif">読み込み中...</p>;
+  }
+
+  const createdDate = formatDate(post.createdAt);
+  const eventDate = formatDate(post.eventDate);
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto font-serif">
+      <LinkBackToHome />
+      <article className="space-y-6">
+        <header className="space-y-2">
+          {createdDate && (
+            <p className="text-sm text-gray-500">公開日: {createdDate}</p>
+          )}
+          {eventDate && (
+            <p className="text-base text-gray-700">実施日: {eventDate}</p>
+          )}
+          <h1 className="text-3xl font-bold">{post.title}</h1>
+        </header>
+        {galleryImages.length > 0 && (
+          <GalleryCarousel images={galleryImages} autoPlayMs={5000} />
+        )}
+        {post.imageUrl && !isUnsafeImageSrc(post.imageUrl) && (
+          <div className="relative w-full h-[240px] sm:h-[360px] rounded-2xl overflow-hidden shadow">
+            <Image src={post.imageUrl} alt={post.title} fill className="object-cover" />
+          </div>
+        )}
+        <div className="text-gray-700 leading-relaxed rich-html">
+          <RichHtml html={stripBlobImages(html)} autoPlayMs={5000} />
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/app/tea-history/page.tsx
+++ b/app/tea-history/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import LinkBackToHome from "@/components/LinkBackToHome";
+import BlogCard from "@/components/BlogCard";
+import { db } from "@/lib/firebase";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
+import type { BlogPost } from "@/types";
+
+function sortTeaArchives(posts: BlogPost[]): BlogPost[] {
+  return [...posts].sort((a, b) => {
+    const ao = typeof a.displayOrder === "number" ? a.displayOrder : Number.MAX_SAFE_INTEGER;
+    const bo = typeof b.displayOrder === "number" ? b.displayOrder : Number.MAX_SAFE_INTEGER;
+    if (ao !== bo) return ao - bo;
+    return (b.eventDate ?? b.createdAt ?? "").localeCompare(a.eventDate ?? a.createdAt ?? "");
+  });
+}
+
+export default function TeaHistoryPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const q = query(
+          collection(db, "teaArchives"),
+          orderBy("displayOrder", "asc")
+        );
+        const snapshot = await getDocs(q);
+        const data = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Omit<BlogPost, "id">) }));
+        setPosts(sortTeaArchives(data));
+      } catch (error) {
+        console.warn("Failed to fetch tea archives with displayOrder", error);
+        const snapshot = await getDocs(collection(db, "teaArchives"));
+        const data = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Omit<BlogPost, "id">) }));
+        setPosts(sortTeaArchives(data));
+      }
+    };
+
+    fetchPosts();
+  }, []);
+
+  return (
+    <main className="p-6 max-w-5xl mx-auto font-serif">
+      <LinkBackToHome />
+      <h1 className="text-2xl font-bold mb-6 text-center">これまでの茶会</h1>
+      <p className="text-center text-sm text-gray-600 mb-8">
+        過去に開催した茶会の記録をご覧いただけます。カルーセルには複数の写真を掲載できます。
+      </p>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map(post => (
+          <BlogCard key={post.id} post={post} href={`/tea-history/${post.id}`} />
+        ))}
+      </div>
+      {posts.length === 0 && (
+        <p className="mt-8 text-center text-gray-500">公開中の記事はまだありません。</p>
+      )}
+    </main>
+  );
+}

--- a/components/BlogCard.tsx
+++ b/components/BlogCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import type { BlogPost } from "@/types";
@@ -12,8 +12,23 @@ interface Props {
   href: string;
 }
 
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  const hasTime = value.includes("T");
+  const date = new Date(hasTime ? value : `${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("ja-JP");
+}
+
 export default function BlogCard({ post, href }: Props) {
-  const date = new Date(post.createdAt).toLocaleDateString("ja-JP");
+  const dateLabel = useMemo(() => {
+    const eventDate = formatDate(post.eventDate ?? undefined);
+    if (eventDate) {
+      return `実施日: ${eventDate}`;
+    }
+    const created = formatDate(post.createdAt);
+    return created ? created : "";
+  }, [post.createdAt, post.eventDate]);
   const [preview, setPreview] = useState("");
 
   useEffect(() => {
@@ -55,7 +70,9 @@ export default function BlogCard({ post, href }: Props) {
       <div className="p-6 font-serif">
         <h2 className="text-2xl font-bold mb-2">{post.title}</h2>
         <p className="text-gray-700">{preview}</p>
-        <p className="text-right text-sm text-gray-500 mt-4">{date}</p>
+        {dateLabel && (
+          <p className="text-right text-sm text-gray-500 mt-4">{dateLabel}</p>
+        )}
       </div>
     </Link>
   );


### PR DESCRIPTION
## Summary
- add a public tea history index that lists tea archive posts with manual ordering
- implement tea history detail view that renders gallery images in a carousel and shows event dates
- enhance blog cards to prioritise event dates when displaying post dates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5e79c1c808324bf3d8dc59825fc3b