### PR TITLE
Prevent admin paste actions from resetting scroll position

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import EnsureAdminCookie from "@/components/EnsureAdminCookie";
+import PreserveScrollOnPaste from "@/components/PreserveScrollOnPaste";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
@@ -8,6 +9,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
       style={{ colorScheme: "light" }}
     >
       <EnsureAdminCookie />
+      <PreserveScrollOnPaste />
       {children}
     </div>
   );

--- a/app/admin2/layout.tsx
+++ b/app/admin2/layout.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
 import EnsureAdminCookie from "@/components/EnsureAdminCookie";
+import PreserveScrollOnPaste from "@/components/PreserveScrollOnPaste";
 
 export default function Admin2Layout({ children }: { children: ReactNode }) {
   return (
     <>
       <EnsureAdminCookie />
+      <PreserveScrollOnPaste />
       {children}
     </>
   );

--- a/components/PreserveScrollOnPaste.tsx
+++ b/components/PreserveScrollOnPaste.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function PreserveScrollOnPaste() {
+  useEffect(() => {
+    const restoreScroll = () => {
+      if (typeof window === "undefined") return;
+      const { scrollX, scrollY } = window;
+      requestAnimationFrame(() => {
+        window.scrollTo(scrollX, scrollY);
+        requestAnimationFrame(() => {
+          window.scrollTo(scrollX, scrollY);
+        });
+      });
+    };
+
+    const options = { capture: true } as const;
+    document.addEventListener("paste", restoreScroll, options);
+    return () => {
+      document.removeEventListener("paste", restoreScroll, options);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a PreserveScrollOnPaste client component that restores the window position after paste events
- include the component in both admin layouts so paste operations no longer jump to the top of the page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df279a66848324aec8c1f63682f89a