### PR TITLE
Prevent admin page scroll jumps during clipboard actions

### DIFF
--- a/components/PreserveScrollOnPaste.tsx
+++ b/components/PreserveScrollOnPaste.tsx
@@ -4,21 +4,42 @@ import { useEffect } from "react";
 
 export default function PreserveScrollOnPaste() {
   useEffect(() => {
+    let rafId: number | null = null;
     const restoreScroll = () => {
       if (typeof window === "undefined") return;
       const { scrollX, scrollY } = window;
-      requestAnimationFrame(() => {
+
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+
+      let remainingTries = 5;
+      const applyScroll = () => {
         window.scrollTo(scrollX, scrollY);
-        requestAnimationFrame(() => {
-          window.scrollTo(scrollX, scrollY);
-        });
-      });
+        remainingTries -= 1;
+        if (remainingTries > 0) {
+          rafId = requestAnimationFrame(applyScroll);
+        } else {
+          rafId = null;
+        }
+      };
+
+      rafId = requestAnimationFrame(applyScroll);
     };
 
     const options = { capture: true } as const;
-    document.addEventListener("paste", restoreScroll, options);
+    const events: Array<keyof DocumentEventMap> = ["paste", "copy", "cut"];
+    events.forEach(event => {
+      document.addEventListener(event, restoreScroll, options);
+    });
     return () => {
-      document.removeEventListener("paste", restoreScroll, options);
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+      events.forEach(event => {
+        document.removeEventListener(event, restoreScroll, options);
+      });
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- expand the clipboard scroll preservation helper to cover copy/paste/cut events and retry restoring the scroll position across multiple animation frames
- cancel any pending restoration loop before starting a new one to keep the latest scroll values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df2ca7907c8324ab7a9117dd95bf0f